### PR TITLE
enhancement(UsedSpace): Synchronise Individual ChunkStore UsedSpace Access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sn_data_types = "~0.11.12"
 sn_transfers = "~0.2.0"
 ed25519 = "1.0.1"
 signature = "1.1.0"
-tokio = { version = "~0.2.5", features = ["macros"] }
+tokio = { version = "~0.2.5", features = ["macros", "fs", "sync"] }
 xor_name = "1.1.0"
 
 [dev_dependencies]

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -110,11 +110,8 @@ impl<T: Chunk> ChunkStore<T> {
         let consumed_space = serialised_chunk.len() as u64;
 
         println!("consumed space: {:?}", consumed_space);
-        println!("max : {:?}", self.max_capacity);
+        println!("max : {:?}", self.used_space.max_capacity().await);
         println!("use space total : {:?}", self.used_space.total().await);
-
-
-        // self.used_space.increase(consumed_space);
 
         let file_path = self.file_path(chunk.id())?;
         let _ = self.do_delete(&file_path).await;

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -121,7 +121,7 @@ impl<T: Chunk> ChunkStore<T> {
 
         let mut file = File::create(&file_path)?;
         file.write_all(&serialised_chunk)?;
-        file.sync_data()?;
+        file.sync_all()?;
 
         self.used_space.increase(self.id, consumed_space).await?;
         println!(

--- a/src/chunk_store/tests.rs
+++ b/src/chunk_store/tests.rs
@@ -90,7 +90,7 @@ async fn successful_put() -> Result<()> {
     let root = temp_dir();
     let used_space = UsedSpace::new(u64::MAX);
     let mut chunk_store =
-        unwrap!(ChunkStore::<Data>::new(root.path(), used_space.clone(), Init::New).await);
+        ChunkStore::<Data>::new(root.path(), used_space.clone(), Init::New).await?;
 
     for (index, (data, size)) in chunks.data_and_sizes.iter().enumerate().rev() {
         let the_data = &Data {
@@ -126,8 +126,7 @@ async fn failed_put_when_not_enough_space() -> Result<()> {
     let root = temp_dir();
     let capacity = 32;
     let used_space = UsedSpace::new(capacity);
-    let mut chunk_store =
-        unwrap!(ChunkStore::new(root.path(), used_space.clone(), Init::New).await);
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
 
     let data = Data {
         id: Id(rng.gen()),
@@ -177,8 +176,7 @@ async fn put_and_get_value_should_be_same() -> Result<()> {
 
     let root = temp_dir();
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store =
-        unwrap!(ChunkStore::new(root.path(), used_space.clone(), Init::New).await);
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
 
     for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
         chunk_store
@@ -226,7 +224,7 @@ async fn get_fails_when_key_does_not_exist() -> Result<()> {
     let root = temp_dir();
     let used_space = UsedSpace::new(u64::MAX);
     let chunk_store: ChunkStore<Data> =
-        unwrap!(ChunkStore::new(root.path(), used_space.clone(), Init::New).await);
+        ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
 
     let id = Id(new_rng().gen());
     match chunk_store.get(&id) {

--- a/src/chunk_store/used_space.rs
+++ b/src/chunk_store/used_space.rs
@@ -38,7 +38,7 @@ impl UsedSpace {
     /// NOTE: this constructs a new async-safe instance,
     /// If you intend to create a new local `ChunkStore` tracking,
     /// then use `clone()` and `add_local_store()` to ensure
-    /// consistentcy across local `ChunkStore`s
+    /// consistency across local `ChunkStore`s
     pub fn new(max_capacity: u64) -> Self {
         Self {
             inner: Arc::new(Mutex::new(inner::UsedSpace::new(max_capacity))),

--- a/src/chunk_store/used_space.rs
+++ b/src/chunk_store/used_space.rs
@@ -9,87 +9,230 @@
 use super::error::{Error, Result};
 use crate::utils::Init;
 // use crate::node::Init;
-use futures::lock::Mutex;
-use std::sync::Arc;
-use std::{
-    fs::{File, OpenOptions},
-    io::{Read, Seek, SeekFrom},
-    path::Path,
-};
+use std::{path::Path, sync::Arc};
+use tokio::sync::Mutex;
 
 const USED_SPACE_FILENAME: &str = "used_space";
 
 /// This holds a record (in-memory and on-disk) of the space used by a single `ChunkStore`, and also
 /// an in-memory record of the total space used by all `ChunkStore`s.
 #[derive(Debug)]
-pub(super) struct UsedSpace {
-    // Total space consumed by all `ChunkStore`s including this one.
-    total_value: Arc<Mutex<u64>>,
-    // Space consumed by this one `ChunkStore`.
-    local_value: u64,
-    // File used to maintain on-disk record of `local_value`.
-    local_record: File,
+pub struct UsedSpace {
+    inner: Arc<Mutex<inner::UsedSpace>>,
+}
+
+/// Identifies a `ChunkStore` within the larger
+/// used space tracking
+pub type StoreId = u64;
+
+impl Clone for UsedSpace {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl UsedSpace {
-    pub fn new<T: AsRef<Path>>(
+    /// construct a new used space instance
+    /// NOTE: this constructs a new async-safe instance,
+    /// If you intend to create a new local `ChunkStore` tracking,
+    /// then use `clone()` and `add_local_store()` to ensure
+    /// consistentcy across local `ChunkStore`s
+    pub fn new(max_capacity: u64) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner::UsedSpace::new(max_capacity))),
+        }
+    }
+
+    /// Add an object and file store to track used space of a single
+    /// `ChunkStore`
+    pub async fn add_local_store<T: AsRef<Path>>(
+        &self,
         dir: T,
-        total_used_space: Arc<Mutex<u64>>,
         init_mode: Init,
-    ) -> Result<Self> {
-        let mut local_record = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(dir.as_ref().join(USED_SPACE_FILENAME))?;
-        let local_value = if init_mode == Init::Load {
-            let mut buffer = vec![];
-            let _ = local_record.read_to_end(&mut buffer)?;
-            // TODO - if this can't be parsed, we should consider emptying `dir` of any chunks.
-            bincode::deserialize::<u64>(&buffer)?
-        } else {
-            bincode::serialize_into(&mut local_record, &0_u64)?;
-            0
-        };
-        Ok(Self {
-            total_value: total_used_space,
-            local_value,
-            local_record,
-        })
+    ) -> Result<StoreId> {
+        inner::UsedSpace::add_local_store(self.inner.clone(), dir, init_mode).await
     }
 
-    /// Returns the total space consumed by all `ChunkStore`s including this one.
-    pub async fn total(&self) -> u64 {
-        *self.total_value.lock().await
+    /// Increase the used amount of a single chunk store and the global used value
+    pub async fn increase(&self, id: StoreId, consumed: u64) -> Result<()> {
+        inner::UsedSpace::increase(self.inner.clone(), id, consumed).await
     }
 
-    pub async fn increase(&mut self, consumed: u64) -> Result<()> {
-        let new_total = self
-            .total_value
-            .lock()
-            .await
-            .checked_add(consumed)
-            .ok_or(Error::NotEnoughSpace)?;
-        let new_local = self
-            .local_value
-            .checked_add(consumed)
-            .ok_or(Error::NotEnoughSpace)?;
-        self.record_new_values(new_total, new_local)
+    /// Decrease the used amount of a single chunk store and the global used value
+    pub async fn decrease(&self, id: StoreId, released: u64) -> Result<()> {
+        inner::UsedSpace::decrease(self.inner.clone(), id, released).await
+    }
+}
+
+mod inner {
+
+    use super::*;
+    use std::{collections::HashMap, io::SeekFrom};
+    use tokio::{
+        fs::{File, OpenOptions},
+        io::{AsyncReadExt, AsyncWriteExt},
+    };
+
+    /// Tracks the Used Space of all `ChunkStore` objects
+    /// registered with it, as well as the combined amount
+    #[derive(Debug)]
+    pub struct UsedSpace {
+        /// the maximum value (inclusive) that `total_value` can attain
+        max_capacity: u64,
+        /// Total space consumed across all `ChunkStore`s, including this one
+        total_value: u64,
+        /// the used space tracking for each chunk store
+        local_stores: HashMap<StoreId, LocalUsedSpace>,
+        /// next local `ChunkStore` id to use
+        next_id: StoreId,
     }
 
-    pub async fn decrease(&mut self, released: u64) -> Result<()> {
-        let new_total = self.total_value.lock().await.saturating_sub(released);
-        let new_local = self.local_value.saturating_sub(released);
-        self.record_new_values(new_total, new_local)
+    /// An entry used to track the used space of a single `ChunkStore`
+    #[derive(Debug)]
+    struct LocalUsedSpace {
+        // Space consumed by this one `ChunkStore`.
+        pub local_value: u64,
+        // File used to maintain on-disk record of `local_value`.
+        // TODO: maybe a good idea to maintain a journal that is only flushed occasionally
+        // to ensure stale entries aren't recorded, and to avoid holding the lock for the
+        // whole inner::UsedSpace struct during the entirety of the file write.
+        pub local_record: File,
     }
 
-    fn record_new_values(&mut self, total: u64, local: u64) -> Result<()> {
-        self.local_record.set_len(0)?;
-        let _ = self.local_record.seek(SeekFrom::Start(0))?;
-        bincode::serialize_into(&self.local_record, &local)?;
+    impl UsedSpace {
+        pub fn new(max_capacity: u64) -> Self {
+            Self {
+                max_capacity: max_capacity,
+                total_value: 0u64,
+                local_stores: HashMap::new(),
+                next_id: 0u64,
+            }
+        }
 
-        self.total_value = Arc::new(Mutex::new(total));
-        self.local_value = local;
-        Ok(())
+        /// Adds a new record for tracking the actions
+        /// of a local chunk store as part of the global
+        /// used amount tracking
+        pub async fn add_local_store<T: AsRef<Path>>(
+            used_space: Arc<Mutex<UsedSpace>>,
+            dir: T,
+            init_mode: Init,
+        ) -> Result<StoreId> {
+            let mut local_record = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(dir.as_ref().join(USED_SPACE_FILENAME))
+                .await?;
+            let local_value = if init_mode == Init::Load {
+                let mut buffer = vec![];
+                let _ = local_record.read_to_end(&mut buffer).await?;
+                // TODO - if this can't be parsed, we should consider emptying `dir` of any chunks.
+                bincode::deserialize::<u64>(&buffer)?
+            } else {
+                let mut bytes = Vec::<u8>::new();
+                bincode::serialize_into(&mut bytes, &0_u64)?;
+                local_record.write_all(&bytes).await?;
+                0
+            };
+
+            let local_store = LocalUsedSpace {
+                local_value,
+                local_record,
+            };
+            let mut used_space_lock = used_space.lock().await;
+            let id = used_space_lock.next_id;
+            used_space_lock.next_id += 1;
+            let _ = used_space_lock.local_stores.insert(id, local_store);
+            Ok(id)
+        }
+
+        /// Asynchronous implementation to increase used space in a local store
+        /// and globally at the same time
+        pub async fn increase(
+            used_space: Arc<Mutex<UsedSpace>>,
+            id: StoreId,
+            consumed: u64,
+        ) -> Result<()> {
+            let mut used_space_lock = used_space.lock().await;
+            let new_total = used_space_lock
+                .total_value
+                .checked_add(consumed)
+                .ok_or(Error::NotEnoughSpace)?;
+            if new_total > used_space_lock.max_capacity {
+                return Err(Error::NotEnoughSpace);
+            }
+            let new_local = used_space_lock
+                .local_stores
+                .get(&id)
+                .unwrap()
+                .local_value
+                .checked_add(consumed)
+                .ok_or(Error::NotEnoughSpace)?;
+
+            {
+                let record = &mut used_space_lock
+                    .local_stores
+                    .get_mut(&id)
+                    .unwrap()
+                    .local_record;
+                Self::write_local_to_file(record, new_local).await?;
+            }
+            used_space_lock.total_value = new_total;
+            used_space_lock
+                .local_stores
+                .get_mut(&id)
+                .unwrap()
+                .local_value = new_local;
+
+            Ok(())
+        }
+
+        /// Asynchronous implementation to decrease used space in a local store
+        /// and globally at the same time
+        pub async fn decrease(
+            used_space: Arc<Mutex<UsedSpace>>,
+            id: StoreId,
+            released: u64,
+        ) -> Result<()> {
+            let mut used_space_lock = used_space.lock().await;
+            let new_local = used_space_lock
+                .local_stores
+                .get_mut(&id)
+                .unwrap()
+                .local_value
+                .saturating_sub(released);
+            let new_total = used_space_lock.total_value.saturating_sub(released);
+            {
+                let record = &mut used_space_lock
+                    .local_stores
+                    .get_mut(&id)
+                    .unwrap()
+                    .local_record;
+                Self::write_local_to_file(record, new_local).await?;
+            }
+            used_space_lock.total_value = new_total;
+            used_space_lock
+                .local_stores
+                .get_mut(&id)
+                .unwrap()
+                .local_value = new_local;
+            Ok(())
+        }
+
+        /// helper to write the contents of local to file
+        /// NOTE: For now, ou should hold the lock on the inner while doing this
+        /// It's slow, but maintains behaviour from the previous implementation
+        async fn write_local_to_file(record: &mut File, local: u64) -> Result<()> {
+            record.set_len(0).await?;
+            let _ = record.seek(SeekFrom::Start(0)).await?;
+
+            let mut contents = Vec::<u8>::new();
+            bincode::serialize_into(&mut contents, &local)?;
+            record.write_all(&contents).await?;
+
+            Ok(())
+        }
     }
 }

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -16,18 +16,17 @@ use chunk_storage::ChunkStorage;
 use log::trace;
 use sn_data_types::{Cmd, DataCmd, DataQuery, Message, MsgEnvelope, Query};
 
-use futures::lock::Mutex;
 use std::fmt::{self, Display, Formatter};
-use std::sync::Arc;
 
 /// Operations on data chunks.
 pub(crate) struct Chunks {
     chunk_storage: ChunkStorage,
 }
+pub use chunk_storage::UsedSpace;
 
 impl Chunks {
-    pub fn new(node_info: &NodeInfo, total_used_space: &Arc<Mutex<u64>>) -> Result<Self> {
-        let chunk_storage = ChunkStorage::new(node_info, total_used_space)?;
+    pub async fn new(node_info: &NodeInfo, used_space: UsedSpace) -> Result<Self> {
+        let chunk_storage = ChunkStorage::new(node_info, used_space).await?;
 
         Ok(Self { chunk_storage })
     }

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -8,15 +8,13 @@
 
 mod chunks;
 
-use self::chunks::Chunks;
+use self::chunks::{Chunks, UsedSpace};
 use crate::{
     node::node_ops::{AdultDuty, ChunkDuty, NodeOperation},
     node::state_db::NodeInfo,
     Result,
 };
-use futures::lock::Mutex;
 use std::fmt::{self, Display, Formatter};
-use std::sync::Arc;
 
 /// The main duty of an Adult node is
 /// storage and retrieval of data chunks.
@@ -25,8 +23,8 @@ pub struct AdultDuties {
 }
 
 impl AdultDuties {
-    pub fn new(node_info: &NodeInfo, total_used_space: &Arc<Mutex<u64>>) -> Result<Self> {
-        let chunks = Chunks::new(node_info, &total_used_space)?;
+    pub async fn new(node_info: &NodeInfo, used_space: UsedSpace) -> Result<Self> {
+        let chunks = Chunks::new(node_info, used_space).await?;
         Ok(Self { chunks })
     }
 

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -16,14 +16,13 @@ use self::{
 
 use crate::{
     capacity::ChunkHolderDbs,
+    chunk_store::UsedSpace,
     node::node_ops::{DataSectionDuty, NodeOperation, RewardDuty},
     node::state_db::NodeInfo,
     utils, Network, Result,
 };
-use futures::lock::Mutex;
 use sn_routing::Prefix;
 use sn_transfers::TransferActor;
-use std::sync::Arc;
 use xor_name::XorName;
 
 /// A DataSection is responsible for
@@ -45,11 +44,11 @@ impl DataSection {
     pub async fn new(
         info: &NodeInfo,
         dbs: ChunkHolderDbs,
-        total_used_space: &Arc<Mutex<u64>>,
+        used_space: UsedSpace,
         network: Network,
     ) -> Result<Self> {
         // Metadata
-        let metadata = Metadata::new(info, dbs, &total_used_space, network.clone())?;
+        let metadata = Metadata::new(info, dbs, used_space, network.clone()).await?;
 
         // Rewards
         let keypair = utils::key_pair(network.clone()).await?;


### PR DESCRIPTION
Simplifies the passing of `used_space` to chunk stores. It creates a shared `UsedSpace` instance which is a thin wrapper to an `Arc<Mutex<UsedSpace>>` and synchronizes access to the global amount of used space (`total_value` and `max_capacity` in code today) and the individual used space for each chunk store. 

**Quick Benefits**
* Paves the way for concurrency within a single `ChunkStore`, not just across `ChunkStore`s (see "Motivation" section below)
* Less implementation bleeding to other modules
    * e.g. no more passing around `Arc<Mutex<u64>> used_space` everywhere. Instead just becomes `used_space.clone()`
* reduced redundancy of shared state and less prone to related bugs
    * e.g. no more need to pass `maximum_capacity` to `ChunkStore` objects, giving each there own copy, which could potentially fall out of sync if it were ever needed to be changed

## Motivation

This doesn't seem to be covered in the big [asysnc PR](https://github.com/maidsafe/safe-vault/pull/1103). This PR seems to cover mostly things related to qp2p and synchronizes access to the global `used_space`, but  not the local used space tracking for any given `ChunkStore<T>`. Currently, the struct `ChunkStore<TChunk>` is not async safe. So while many of their functions may be denoted `async` after that linked PR is merged, the vault doesn't currently have the flexibility to leverage concurrency for multiple vault operations. 

Thus, statements like the following, or potential architectural changes of similar nature would not be possible, limiting the vault's potential for performance:

    // Currently, not possible (even after PR merges)
    let tasks = Vec::new();
    for _ in 0..10 {
        tasks.push( chunk_store.do_concurrent_operation() );
    }
    future::futures::try_join_all(&tasks).await?

Instead, we would need something like the following, code, which would `await` each operation, which could otherwise be run concurrently, before running the next.

    // Only this is possible right now (even after PR merges)
    for _ in 0..10 {
        chunk_store.do_operation().await;
   }

So the current architecture allows concurrency for connections, it's still limiting for chunk store operations.

The first step to enabling chunk store operations to run concurrently, is to simplify the interface to `UsedSpace`, so the `local_value` of the `UsedSpace` struct that each `ChunkStore<T>` holds, as well as the file `used_space` for each chunk store, tracks properly across multiple operations on potentially separate threads.

## Related

I mentioned this briefly in a couple of places, and it's currently not a part of the [`async` PR](https://github.com/maidsafe/safe-vault/pull/1103) as I mentioned above. I did mention it [here](https://forum.safedev.org/t/still-using-synchronous-file-i-o-in-vaults/2881) in the forums and in a git issue I raised earlier, #1094 and alluded to in and PR #1090. This PR is part of #1094  but doesn't fully close it per say, but it would be the first step.