### PR TITLE
chore(name): update safe-vault repo/crate name to sn_node

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ If applicable, add screenshots to help explain your problem.
  - OS: [e.g. Ubuntu 18.04]
  - Shell: [e.g. Zsh]
  - Rust: [e.g. 1.42.0 stable]
- - safe_vault crate version [e.g. 0.20.1]
+ - sn_node crate version [e.g. 0.20.1]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
  - etc

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload artifacts.
       - uses: actions/upload-artifact@master
         with:
-          name: safe_vault-${{ matrix.target }}-prod
+          name: sn_node-${{ matrix.target }}-prod
           path: artifacts
 
   build_linux:
@@ -99,7 +99,7 @@ jobs:
       # Upload artifacts.
       - uses: actions/upload-artifact@master
         with:
-          name: safe_vault-${{ matrix.target }}-prod
+          name: sn_node-${{ matrix.target }}-prod
           path: artifacts
 
   # Unfortunately, for artifact retrieval, there's not really a way to avoid having this huge list of
@@ -119,15 +119,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@master
         with:
-          name: safe_vault-x86_64-pc-windows-msvc-prod
+          name: sn_node-x86_64-pc-windows-msvc-prod
           path: artifacts/prod/x86_64-pc-windows-msvc/release
       - uses: actions/download-artifact@master
         with:
-          name: safe_vault-x86_64-unknown-linux-musl-prod
+          name: sn_node-x86_64-unknown-linux-musl-prod
           path: artifacts/prod/x86_64-unknown-linux-musl/release
       - uses: actions/download-artifact@master
         with:
-          name: safe_vault-x86_64-apple-darwin-prod
+          name: sn_node-x86_64-apple-darwin-prod
           path: artifacts/prod/x86_64-apple-darwin/release
 
       # Get information for the release.
@@ -166,14 +166,14 @@ jobs:
 
       # Upload all the release archives to S3
       - name: Upload archives to S3
-        run: aws s3 sync deploy/prod s3://safe-vault --acl public-read
+        run: aws s3 sync deploy/prod s3://sn-node --acl public-read
 
-      # Create the release and attach safe_vault archives as assets.
+      # Create the release and attach sn_node archives as assets.
       - uses: csexton/create-release@add-body
         id: create_release
         with:
           tag_name: ${{ steps.versioning.outputs.version }}
-          release_name: safe_vault
+          release_name: sn_node
           draft: false
           prerelease: false
           body: ${{ steps.release_description.outputs.description }}
@@ -183,22 +183,22 @@ jobs:
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_vault-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
-          asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_vault-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
-          asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_vault-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
-          asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 
@@ -206,22 +206,22 @@ jobs:
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_vault-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
-          asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_vault-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
-          asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_vault-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
-          asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ packages/
 .DS_Store
 *.back.aip
 .env
-installer/docker/safe_vault
-installer/docker/safe_vault.*.config
+installer/docker/sn_node
+installer/docker/sn_node.*.config
 installer/docker/.env
-vaults
+nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
-# Safe Vault - Change Log
+# Changelog
 
 ## [0.24.0]
-- When a Vault starts, start it as an Adult. Create the additional modules required only when it is promoted to an Elder.
+- When a Node starts, start it as an Adult. Create the additional modules required only when it is promoted to an Elder.
 - Give Adults the responsibility of holding Immutable Data chunks.
 - Use routing's messaging API with signature accumulation for intra-section communication.
 - Implement chunk duplication if a node leaves the network. This will maintain the minimum number of copies required.
 - Update to the latest version of `quic-p2p` which enables automatic port forwarding using the IGD protocol.
-- Gracefully end the vault process on SIGINT.
+- Gracefully end the node process on SIGINT.
 - Use the latest version of `routing`.
 - Update to safe-nd 0.9.0 with refactored `Request` and `Response` enums.
 - Separate the Client Handler into smaller sub-modules.
@@ -36,7 +36,7 @@
 - Send UpdateLoginPacket req via consensus
 - update to safe-nd 0.4.0
 - refactor test to verify granulated app permissions
-- allow to use multiple vaults for tests
+- allow to use multiple nodes for tests
 - add consensus votes on CreateBalance requests
 - send insert and delete auth keys request via…
 - change usage of idata term "kind" to "data"
@@ -61,7 +61,7 @@
 - rename --dump-completions to --completions for consisten…
 - fix test case
 - fix smoke test failure.
-- make vault rng seeded from routing's
+- make node rng seeded from routing's
 - Merge pull request #912 from maqi/use_same_rng
 - add caching and other changes to GHA
 - resolve non-producable issue
@@ -73,13 +73,13 @@
 - update testing framework to new handshake format
 - Merge pull request #911 from octol/new-bootstrap-handshake-format
 - use real routing for the integration test
-- make client requests handled by vault network
+- make client requests handled by node network
 - enable tests with feature of mock
 - Small tidy up of imports for routing API cleanup
 - fix clippy::needless_pass_by_value
 - Re-order use and pub use statements.
 - include path info in error strings
-- fixup/vault: formatting
+- fixup/node: formatting
 - Merge pull request #919 from dirvine/vNext
 - Merge pull request #909 from dan-da/completions_pr
 - update routing dependecy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,51 +2342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "safe_vault"
-version = "0.24.0"
-dependencies = [
- "async-log",
- "base64 0.10.1",
- "bincode",
- "bytes 0.5.6",
- "crdts",
- "crossbeam-channel",
- "ctrlc",
- "directories 2.0.2",
- "ed25519",
- "ed25519-dalek",
- "flexi_logger",
- "futures",
- "fxhash",
- "hex",
- "hex_fmt",
- "lazy_static",
- "log",
- "maplit",
- "pickledb",
- "quick-error",
- "rand 0.7.3",
- "rand_chacha",
- "safe_core",
- "self_update",
- "serde",
- "serde_json",
- "sha2 0.8.2",
- "signature",
- "sn_data_types",
- "sn_fake_clock",
- "sn_routing",
- "sn_transfers",
- "structopt 0.3.17",
- "tempdir",
- "threshold_crypto",
- "tiny-keccak 1.5.0",
- "tokio",
- "unwrap",
- "xor_name",
-]
-
-[[package]]
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2575,51 @@ name = "sn_fake_clock"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b3bb89541a5068ba2861181892745587897765ea2724b78257eb5f289de16ab"
+
+[[package]]
+name = "sn_node"
+version = "0.24.0"
+dependencies = [
+ "async-log",
+ "base64 0.10.1",
+ "bincode",
+ "bytes 0.5.6",
+ "crdts",
+ "crossbeam-channel",
+ "ctrlc",
+ "directories 2.0.2",
+ "ed25519",
+ "ed25519-dalek",
+ "flexi_logger",
+ "futures",
+ "fxhash",
+ "hex",
+ "hex_fmt",
+ "lazy_static",
+ "log",
+ "maplit",
+ "pickledb",
+ "quick-error",
+ "rand 0.7.3",
+ "rand_chacha",
+ "safe_core",
+ "self_update",
+ "serde",
+ "serde_json",
+ "sha2 0.8.2",
+ "signature",
+ "sn_data_types",
+ "sn_fake_clock",
+ "sn_routing",
+ "sn_transfers",
+ "structopt 0.3.17",
+ "tempdir",
+ "threshold_crypto",
+ "tiny-keccak 1.5.0",
+ "tokio",
+ "unwrap",
+ "xor_name",
+]
 
 [[package]]
 name = "sn_routing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
-description = "Implementation of the 'Vault' node for the SAFE Network."
-documentation = "https://docs.rs/safe_vault"
+description = "Implementation of the nodes for the Safe Network."
+documentation = "https://docs.rs/sn_node"
 edition = "2018"
 homepage = "https://maidsafe.net"
 license = "GPL-3.0"
-name = "safe_vault"
+name = "sn_node"
 readme = "README.md"
-repository = "https://github.com/maidsafe/safe_vault"
+repository = "https://github.com/maidsafe/sn_node"
 version = "0.24.0"
 
 [patch.crates-io]
@@ -65,7 +65,7 @@ tokio = { version="~0.2.21", features=["rt-core", "blocking", "stream", "rt-util
 futures = "~0.3.5"
 
 [[bin]]
-name = "safe_vault"
+name = "sn_node"
 doc = false
 
 [features]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -40,17 +40,17 @@ RUN apt-get update -y && \
     CC=musl-gcc C_INCLUDE_PATH=/usr/local/musl/include/ make install && \
     mkdir /target && \
     chown maidsafe:maidsafe /target && \
-    mkdir /usr/src/safe_vault && \
-    chown maidsafe:maidsafe /usr/src/safe_vault && \
+    mkdir /usr/src/sn_node && \
+    chown maidsafe:maidsafe /usr/src/sn_node && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/src/safe_vault
+WORKDIR /usr/src/sn_node
 COPY . .
 
 # During the build process, ownership of the source directory needs changed in advance because
 # the tests write a file and you need permissions for that.
-RUN chown -R maidsafe:maidsafe /usr/src/safe_vault
+RUN chown -R maidsafe:maidsafe /usr/src/sn_node
 USER maidsafe:maidsafe
 ENV CARGO_TARGET_DIR=/target \
     RUST_BACKTRACE=1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                           LINKING EXCEPTION
 
-safe_vault is distributed under the terms of the GNU General Public
+sn_node is distributed under the terms of the GNU General Public
 License (v3) with the following clarification and special exception.
 Linking this library statically or dynamically with other modules is
 making a combined work based on this library. Thus, the terms and

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# SAFE Vault
+# sn_node
 
 |Crate|Documentation|Safe Rust|
 |:---:|:-----------:|:-------:|
-|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+|[![](http://meritbadge.herokuapp.com/sn_node)](https://crates.io/crates/sn_node)|[![Documentation](https://docs.rs/sn_node/badge.svg)](https://docs.rs/sn_node)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
-| [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+| [MaidSafe website](https://maidsafe.net) | [Safe Dev Forum](https://forum.safedev.org) | [Safe Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
 
 ## Overview
@@ -14,7 +14,7 @@ An autonomous network capable of data storage/publishing/sharing as well as comp
 ## Crate Dependencies
 Crate dependencies graph:
 
-![safe_vault MaidSafe dependencies](https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_maidsafe_dependencies.png)
+![sn_node MaidSafe dependencies](https://github.com/maidsafe/sn_node/blob/png_generator/sn_node_maidsafe_dependencies.png)
 
 
 ### Legend
@@ -28,10 +28,10 @@ A dependency can be of more than one kind. In such cases, it is coloured with th
 `Regular -> Build -> Dev -> Optional`
 
 <details>
-<summary> View all safe_vault dependencies</summary>
+<summary> View all sn_node dependencies</summary>
 <p>
 
-![safe_vault all dependencies](https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_all_dependencies.png)
+![sn_node all dependencies](https://github.com/maidsafe/sn_node/blob/png_generator/sn_node_all_dependencies.png)
 
 </p>
 </details>
@@ -40,11 +40,11 @@ Click [here](https://maidsafe.github.io/interdependency-svg-generator/) for an o
 
 ## License
 
-This SAFE Network library is licensed under the General Public License (GPL), version 3 ([LICENSE](LICENSE) https://www.gnu.org/licenses/gpl-3.0.en.html).
+This Safe Network library is licensed under the General Public License (GPL), version 3 ([LICENSE](LICENSE) https://www.gnu.org/licenses/gpl-3.0.en.html).
 
 ### Linking exception
 
-safe_vault is licensed under GPLv3 with linking exception. This means you can link to and use the library from any program, proprietary or open source; paid or gratis. However, if you modify safe_vault, you must distribute the source to your modified version under the terms of the GPLv3.
+sn_node is licensed under GPLv3 with linking exception. This means you can link to and use the library from any program, proprietary or open source; paid or gratis. However, if you modify sn_node, you must distribute the source to your modified version under the terms of the GPLv3.
 
 See [the LICENSE file](LICENSE) for more details.
 

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -7,5 +7,5 @@ mkdir images
 
 cargo install cargo-deps
 
-cargo deps --all-deps --include-orphans --filter safe_vault safe-nd routing quic-p2p lru_time_cache sn_fake_clock xor_name bls_dkg bls_signature_aggregator sn_transfers | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
-cargo deps | dot -T png -o images/safe_vault_all_dependencies.png
+cargo deps --all-deps --include-orphans --filter sn_node safe-nd sn_routing qp2p lru_time_cache sn_fake_clock xor_name bls_dkg bls_signature_aggregator sn_transfers | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/sn_node_maidsafe_dependencies.png
+cargo deps | dot -T png -o images/sn_node_all_dependencies.png

--- a/scripts/get_release_description.sh
+++ b/scripts/get_release_description.sh
@@ -8,7 +8,7 @@ fi
 
 # The single quotes around EOF is to stop attempted variable and backtick expansion.
 read -r -d '' release_description << 'EOF'
-Implements a Safe Network Vault.
+Implements a Safe Network Node.
 
 ## SHA-256 checksums for release versions:
 ```
@@ -31,22 +31,22 @@ tar.gz: TAR_WIN_CHECKSUM
 EOF
 
 zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/safe_vault-$version-x86_64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 zip_macos_checksum=$(sha256sum \
-    "./deploy/prod/safe_vault-$version-x86_64-apple-darwin.zip" | \
+    "./deploy/prod/sn_node-$version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 zip_win_checksum=$(sha256sum \
-    "./deploy/prod/safe_vault-$version-x86_64-pc-windows-msvc.zip" | \
+    "./deploy/prod/sn_node-$version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
 tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/safe_vault-$version-x86_64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 tar_macos_checksum=$(sha256sum \
-    "./deploy/prod/safe_vault-$version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/sn_node-$version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 tar_win_checksum=$(sha256sum \
-    "./deploy/prod/safe_vault-$version-x86_64-pc-windows-msvc.tar.gz" | \
+    "./deploy/prod/sn_node-$version-x86_64-pc-windows-msvc.tar.gz" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/ZIP_LINUX_CHECKSUM/$zip_linux_checksum/g" <<< "$release_description")

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -33,9 +33,9 @@ lazy_static! {
 
 const CONFIG_DIR_QUALIFIER: &str = "net";
 const CONFIG_DIR_ORGANISATION: &str = "MaidSafe";
-const CONFIG_DIR_APPLICATION: &str = "safe_vault";
-const CONFIG_FILE: &str = "vault.config";
-const CONNECTION_INFO_FILE: &str = "vault_connection_info.config";
+const CONFIG_DIR_APPLICATION: &str = "sn_node";
+const CONFIG_FILE: &str = "node.config";
+const CONNECTION_INFO_FILE: &str = "node_connection_info.config";
 const DEFAULT_ROOT_DIR_NAME: &str = "root_dir";
 const DEFAULT_MAX_CAPACITY: u64 = 2 * 1024 * 1024 * 1024;
 const ARGS: [&str; 17] = [
@@ -58,30 +58,30 @@ const ARGS: [&str; 17] = [
     "local",
 ];
 
-/// Vault configuration
+/// Node configuration
 #[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, StructOpt)]
-#[structopt(rename_all = "kebab-case", bin_name = "safe_vault")]
+#[structopt(rename_all = "kebab-case", bin_name = "sn_node")]
 #[structopt(global_settings = &[structopt::clap::AppSettings::ColoredHelp])]
 pub struct Config {
-    /// The address to be credited when this vault farms SafeCoin.
+    /// The address to be credited when this node farms SafeCoin.
     /// A hex formatted BLS public key.
     #[structopt(short, long, parse(try_from_str))]
     wallet_id: Option<String>,
-    /// Upper limit in bytes for allowed network storage on this vault.
+    /// Upper limit in bytes for allowed network storage on this node.
     #[structopt(short, long)]
     max_capacity: Option<u64>,
     /// Root directory for ChunkStores and cached state. If not set, it defaults to "root_dir"
-    /// within the safe_vault project data directory, located at... Linux: $XDG_DATA_HOME/safe_vault
-    /// or $HOME/.local/share/safe_vault | Windows:
-    /// {FOLDERID_RoamingAppData}/MaidSafe/safe_vault/data | MacOS: $HOME/Library/Application
-    /// Support/net.MaidSafe.safe_vault
+    /// within the sn_node project data directory, located at... Linux: $XDG_DATA_HOME/sn_node
+    /// or $HOME/.local/share/sn_node | Windows:
+    /// {FOLDERID_RoamingAppData}/MaidSafe/sn_node/data | MacOS: $HOME/Library/Application
+    /// Support/net.MaidSafe.sn_node
     #[structopt(short, long, parse(from_os_str))]
     root_dir: Option<PathBuf>,
     /// Verbose output. `-v` is equivalent to logging with `warn`, `-vv` to `info`, `-vvv` to
     /// `debug`, `-vvvv` to `trace`. This flag overrides RUST_LOG.
     #[structopt(short, long, parse(from_occurrences))]
     verbose: u64,
-    /// Is the vault running for a local section?
+    /// Is the node running for a local section?
     #[structopt(short, long)]
     local: bool,
     /// Is this the first node in a section?
@@ -99,13 +99,13 @@ pub struct Config {
     /// Attempt to self-update?
     #[structopt(long)]
     update: bool,
-    /// Attempt to self-update without starting the vault process
+    /// Attempt to self-update without starting the node process
     #[structopt(long, name = "update-only")]
     update_only: bool,
 }
 
 impl Config {
-    /// Returns a new `Config` instance.  Tries to read from the default vault config file location,
+    /// Returns a new `Config` instance.  Tries to read from the default node config file location,
     /// and overrides values with any equivalent command line args.
     pub fn new() -> Self {
         let mut config = match Self::read_from_file() {
@@ -128,7 +128,7 @@ impl Config {
         config
     }
 
-    /// The address to be credited when this vault farms SafeCoin.
+    /// The address to be credited when this node farms SafeCoin.
     pub fn wallet_id(&self) -> Option<&String> {
         self.wallet_id.as_ref()
     }
@@ -138,12 +138,12 @@ impl Config {
         self.first
     }
 
-    /// Is the vault running for a local section?
+    /// Is the node running for a local section?
     pub fn is_local(&self) -> bool {
         self.local
     }
 
-    /// Upper limit in bytes for allowed network storage on this vault.
+    /// Upper limit in bytes for allowed network storage on this node.
     pub fn max_capacity(&self) -> u64 {
         self.max_capacity.unwrap_or(DEFAULT_MAX_CAPACITY)
     }
@@ -204,7 +204,7 @@ impl Config {
         self.update
     }
 
-    /// Attempt to self-update without starting the vault process
+    /// Attempt to self-update without starting the node process
     pub fn update_only(&self) -> bool {
         self.update_only
     }
@@ -270,7 +270,7 @@ impl Config {
         }
     }
 
-    /// Reads the default vault config file.
+    /// Reads the default node config file.
     fn read_from_file() -> Result<Option<Config>> {
         let path = project_dirs()?.config_dir().join(CONFIG_FILE);
 
@@ -292,12 +292,12 @@ impl Config {
         }
     }
 
-    /// Writes a Vault config file **for use by tests and examples**.
+    /// Writes a Node config file **for use by tests and examples**.
     ///
     /// The file is written to the `current_bin_dir()` with the appropriate file name.
     ///
     /// N.B. This method should only be used as a utility for test and examples.  In normal use cases,
-    /// the config file should be created by the Vault's installer.
+    /// the config file should be created by the Node's installer.
     #[cfg(test)]
     #[allow(dead_code)]
     pub fn write_config_file(&self) -> Result<PathBuf> {
@@ -417,7 +417,7 @@ mod test {
     #[ignore]
     #[test]
     fn parse_sample_config_file() {
-        let path = Path::new("installer/common/sample.vault.config").to_path_buf();
+        let path = Path::new("installer/common/sample.node.config").to_path_buf();
         let mut file = unwrap!(File::open(&path), "Error opening {}:", path.display());
         let mut encoded_contents = String::new();
         let _ = unwrap!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use std::io;
 quick_error! {
     #[allow(clippy::large_enum_variant)]
     #[derive(Debug)]
-    /// Vault error variants.
+    /// Node error variants.
     pub enum Error {
         /// Error in ChunkStore.
         ChunkStore(error: chunk_store::error::Error) {
@@ -86,5 +86,5 @@ quick_error! {
     }
 }
 
-/// Specialisation of `std::Result` for Vault.
+/// Specialisation of `std::Result` for Node.
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//! Implementation of the "Vault" node for the SAFE Network.
+//! Implementation of the "Node" node for the SAFE Network.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -7,13 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Network;
-use safe_core::client::{
-    blob_apis::exported_tests as blob_tests, exported_tests as client_tests,
-    map_apis::exported_tests as map_tests, sequence_apis::exported_tests as sequence_tests,
-};
+use safe_core::client::exported_tests as client_tests;
 use std::sync::Once;
 
-static mut NETWORK: Network = Network { vaults: Vec::new() };
+static mut NETWORK: Network = Network { nodes: Vec::new() };
 static START: Once = Once::new();
 
 #[allow(unsafe_code)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,15 +19,15 @@ use std::thread::JoinHandle;
 #[derive(Default)]
 struct Network {
     #[allow(unused)]
-    vaults: Vec<(Sender<Command>, JoinHandle<()>)>,
+    nodes: Vec<(Sender<Command>, JoinHandle<()>)>,
 }
 
 impl Network {
-    pub async fn new(no_of_vaults: usize) -> Self {
-        let path = std::path::Path::new("vaults");
-        std::fs::remove_dir_all(&path).unwrap_or(()); // Delete vaults directory if it exists;
-        std::fs::create_dir_all(&path).expect("Cannot create vaults directory");
-        let mut vaults = Vec::new();
+    pub async fn new(no_of_nodes: usize) -> Self {
+        let path = std::path::Path::new("nodes");
+        std::fs::remove_dir_all(&path).unwrap_or(()); // Delete nodes directory if it exists;
+        std::fs::create_dir_all(&path).expect("Cannot create nodes directory");
+        let mut nodes = Vec::new();
         let genesis_info: SocketAddr = "127.0.0.1:12000".parse().unwrap();
         let mut node_config = Config::default();
         node_config.set_flag("verbose", 4);
@@ -38,11 +38,11 @@ impl Network {
         let (command_tx, _command_rx) = crossbeam_channel::bounded(1);
         let mut genesis_config = node_config.clone();
         let handle = std::thread::Builder::new()
-            .name("vault-genesis".to_string())
+            .name("node-genesis".to_string())
             .spawn(move || {
                 let mut runtime = tokio::runtime::Runtime::new().unwrap();
                 genesis_config.set_flag("first", 1);
-                let path = path.join("genesis-vault");
+                let path = path.join("genesis-node");
                 std::fs::create_dir_all(&path).expect("Cannot create genesis directory");
                 genesis_config.set_root_dir(&path);
                 genesis_config.listen_on_loopback();
@@ -52,7 +52,7 @@ impl Network {
                 routing_config.transport_config = genesis_config.network_config().clone();
                 let mut node = runtime
                     .block_on(Node::new(&genesis_config, rand::rngs::OsRng::default()))
-                    .expect("Unable to start vault Node");
+                    .expect("Unable to start Node");
                 let our_conn_info = runtime
                     .block_on(node.our_connection_info())
                     .expect("Could not get genesis info");
@@ -60,35 +60,35 @@ impl Network {
                 let _ = runtime.block_on(node.run()).unwrap();
             })
             .unwrap();
-        vaults.push((command_tx, handle));
-        for i in 1..no_of_vaults {
+        nodes.push((command_tx, handle));
+        for i in 1..no_of_nodes {
             thread::sleep(std::time::Duration::from_secs(30));
             let mut runtime = tokio::runtime::Runtime::new().unwrap();
             let (command_tx, _command_rx) = crossbeam_channel::bounded(1);
-            let mut vault_config = node_config.clone();
+            let mut node_config = node_config.clone();
             let handle = thread::Builder::new()
-                .name(format!("vault-{n}", n = i))
+                .name(format!("node-{n}", n = i))
                 .spawn(move || {
-                    let vault_path = path.join(format!("vault-{}", i));
-                    println!("Starting new vault: {:?}", &vault_path);
-                    std::fs::create_dir_all(&vault_path).expect("Cannot create vault directory");
-                    vault_config.set_root_dir(&vault_path);
+                    let node_path = path.join(format!("node-{}", i));
+                    println!("Starting new node: {:?}", &node_path);
+                    std::fs::create_dir_all(&node_path).expect("Cannot create node directory");
+                    node_config.set_root_dir(&node_path);
 
                     let mut network_config = NetworkConfig::default();
                     let _ = network_config.hard_coded_contacts.insert(genesis_info);
-                    vault_config.set_network_config(network_config);
-                    vault_config.listen_on_loopback();
+                    node_config.set_network_config(network_config);
+                    node_config.listen_on_loopback();
 
                     let mut routing_config = RoutingConfig::default();
-                    routing_config.transport_config = vault_config.network_config().clone();
+                    routing_config.transport_config = node_config.network_config().clone();
                     let rng = rand::rngs::OsRng::default();
-                    let mut node = runtime.block_on(Node::new(&vault_config, rng)).unwrap();
+                    let mut node = runtime.block_on(Node::new(&node_config, rng)).unwrap();
                     let _ = runtime.block_on(node.run()).unwrap();
                 })
                 .unwrap();
-            vaults.push((command_tx, handle));
+            nodes.push((command_tx, handle));
         }
         thread::sleep(std::time::Duration::from_secs(30));
-        Self { vaults }
+        Self { nodes }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,7 @@ use std::io::Write;
 use std::{fs, path::Path};
 use unwrap::unwrap;
 
-const VAULT_MODULE_NAME: &str = "safe_vault";
+const NODE_MODULE_NAME: &str = "sn_node";
 
 /// Specifies whether to try loading cached data from disk, or to just construct a new instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,7 +104,7 @@ pub fn init_logging(config: &Config) {
     };
 
     let level_filter = config.verbose().to_level_filter();
-    let module_log_filter = format!("{}={}", VAULT_MODULE_NAME, level_filter.to_string());
+    let module_log_filter = format!("{}={}", NODE_MODULE_NAME, level_filter.to_string());
     let logger = Logger::with_env_or_str(module_log_filter)
         .format(do_format)
         .suppress_timestamp();
@@ -143,6 +143,6 @@ impl Log for LoggerWrapper {
 /// Command that the user can send to a running node to control its execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Command {
-    /// Shutdown the vault
+    /// Shutdown the node
     Shutdown,
 }


### PR DESCRIPTION
This updates all `vault` references to `node`, including S3
bucket, artifacts, variable names, etc.
Once merged, the `sn_node` crate should be published asap (if stable)