### PR TITLE
Ci add chaos

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release  --features=simulated-payouts
+          args: --release  --features=simulated-payouts,chaos
 
       - name: Upload node data on fail
         if: ${{ failure() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "sn_client"
 version = "0.42.1"
-source = "git+https://github.com/maidsafe/sn_client#40696480046217a3ab7e3bf9dea1d95c09b3289d"
+source = "git+https://github.com/maidsafe/sn_client#3114c47bf94ca3be8c5645a42d8b69a999568f29"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,8 +820,11 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
+ "atty",
+ "humantime",
  "log",
  "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -2595,6 +2598,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36db4bb99ee5a030e784804baf120d4e93dc8122017228f8ed71ab123d9fe3d4"
 
 [[package]]
+name = "sn_launch_tool"
+version = "0.0.1"
+source = "git+https://github.com/maidsafe/sn_launch_tool.git#465bc54f995528123b0b38cd0b28bd3cfab3ed9d"
+dependencies = [
+ "directories 2.0.2",
+ "env_logger 0.7.1",
+ "log",
+ "regex",
+ "structopt 0.3.18",
+]
+
+[[package]]
 name = "sn_node"
 version = "0.24.0"
 dependencies = [
@@ -2628,6 +2643,7 @@ dependencies = [
  "sn_client",
  "sn_data_types",
  "sn_fake_clock",
+ "sn_launch_tool",
  "sn_routing",
  "sn_transfers",
  "structopt 0.3.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ ed25519 = "1.0.1"
 signature = "1.1.0"
 tokio = { version = "~0.2.5", features = ["macros", "fs", "sync"] }
 xor_name = "1.1.0"
+sn_launch_tool = { git = "https://github.com/maidsafe/sn_launch_tool.git" }
 
 [dev_dependencies]
 maplit = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,4 @@ doc = false
 
 [features]
 simulated-payouts = ["sn_data_types/simulated-payouts", "sn_transfers/simulated-payouts", "sn_client/simulated-payouts"]
+chaos = []

--- a/src/bin/launch_network.rs
+++ b/src/bin/launch_network.rs
@@ -1,0 +1,135 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! sn_node provides the interface to Safe routing.  The resulting executable is the node
+//! for the Safe network.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
+    html_favicon_url = "https://maidsafe.net/img/favicon.ico",
+    test(attr(forbid(warnings)))
+)]
+// For explanation of lint checks, run `rustc -W help`.
+#![forbid(unsafe_code)]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
+)]
+
+use directories::BaseDirs;
+use log::{debug, info};
+use sn_launch_tool::run_with;
+use std::{
+    fs::{create_dir_all, remove_dir_all},
+    path::PathBuf,
+};
+use tokio::time::{delay_for, Duration};
+
+#[cfg(not(target_os = "windows"))]
+const SAFE_NODE_EXECUTABLE: &str = "sn_node";
+
+#[cfg(target_os = "windows")]
+const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
+
+static NODES_DIR: &str = "local-test-network";
+static INTERVAL: &str = "3";
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let path = std::path::Path::new("nodes");
+    remove_dir_all(&path).unwrap_or(()); // Delete nodes directory if it exists;
+    create_dir_all(&path).expect("Cannot create nodes directory");
+
+    let _ = run_network().await?;
+
+    Ok(())
+}
+
+fn get_node_bin_path(node_path: Option<PathBuf>) -> Result<PathBuf, String> {
+    match node_path {
+        Some(p) => Ok(p),
+        None => {
+            let base_dirs =
+                BaseDirs::new().ok_or_else(|| "Failed to obtain user's home path".to_string())?;
+
+            let mut path = PathBuf::from(base_dirs.home_dir());
+            path.push(".safe");
+            path.push("node");
+            Ok(path)
+        }
+    }
+}
+
+/// Uses SNLT to create a local network of nodes
+pub async fn run_network() -> Result<(), String> {
+    info!("Starting local network");
+    let verbosity = 4;
+    let node_path = Some(PathBuf::from("./target/release"));
+    let node_path = get_node_bin_path(node_path)?;
+
+    let arg_node_path = node_path.join(SAFE_NODE_EXECUTABLE).display().to_string();
+    debug!("Running node from {}", arg_node_path);
+
+    let base_log_dir = get_node_bin_path(None)?;
+    let node_log_dir = base_log_dir.join(NODES_DIR);
+    if !node_log_dir.exists() {
+        debug!("Creating '{}' folder", node_log_dir.display());
+        create_dir_all(node_log_dir.clone()).map_err(|err| {
+            format!(
+                "Couldn't create target path to store nodes' generated data: {}",
+                err
+            )
+        })?;
+    }
+    let arg_node_log_dir = node_log_dir.display().to_string();
+    info!("Storing nodes' generated data at {}", arg_node_log_dir);
+
+    // Let's create an args array to pass to the network launcher tool
+    let mut sn_launch_tool_args = vec![
+        "sn_launch_tool",
+        "-v",
+        "--node-path",
+        &arg_node_path,
+        "--nodes-dir",
+        &arg_node_log_dir,
+        "--interval",
+        &INTERVAL,
+        "--local",
+    ];
+
+    let interval_as_int = &INTERVAL.parse::<u64>().unwrap();
+
+    let mut verbosity_arg = String::from("-");
+    if verbosity > 0 {
+        let v = "y".repeat(verbosity as usize);
+        info!("V: {}", v);
+        verbosity_arg.push_str(&v);
+        sn_launch_tool_args.push(&verbosity_arg);
+    }
+
+    debug!(
+        "Running network launch tool with args: {:?}",
+        sn_launch_tool_args
+    );
+
+    // We can now call the tool with the args
+    info!("Launching local Safe network...");
+    run_with(Some(&sn_launch_tool_args))?;
+
+    let interval_duration = Duration::from_secs(interval_as_int * 15);
+
+    delay_for(interval_duration).await;
+
+    Ok(())
+}

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -1,0 +1,31 @@
+/// Run code when a chaotic. Defaults to 20% of the time. Overall frequence can be set via "SAFE_CHAOS_LEVEL" env var.
+#[macro_export]
+macro_rules! with_chaos {
+    ( $x:expr) => {{
+        #[cfg(feature = "chaos")]
+        {
+            use log::{debug, warn};
+            use rand::distributions::{Distribution, Uniform};
+            use std::env;
+
+            let mut rng = rand::thread_rng();
+            // 20% chance of happening
+            let chaos_trigger: usize = env::var("SAFE_CHAOS_LEVEL")
+                .unwrap_or("20".to_string())
+                .parse()
+                .unwrap();
+            let die = Uniform::from(1..100);
+            let throw = die.sample(&mut rng);
+            debug!(
+                "Threshold for \"chaos\" to occur is > {}, we rolled: {}",
+                chaos_trigger, throw
+            );
+
+            if throw <= chaos_trigger {
+                // do the chaos
+                warn!("Chaos!");
+                $x
+            }
+        }
+    }};
+}

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -17,7 +17,7 @@ macro_rules! with_chaos {
             let die = Uniform::from(1..100);
             let throw = die.sample(&mut rng);
             debug!(
-                "Threshold for \"chaos\" to occur is > {}, we rolled: {}",
+                "Threshold for \"chaos\" to occur is < {}, we rolled: {}",
                 chaos_trigger, throw
             );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 #![recursion_limit = "128"]
 
 mod capacity;
+mod chaos;
 mod chunk_store;
 mod config_handler;
 mod error;

--- a/src/node/elder_duties/key_section/client/client_msg_handling.rs
+++ b/src/node/elder_duties/key_section/client/client_msg_handling.rs
@@ -103,7 +103,13 @@ impl ClientMsgHandling {
     ) -> Option<NodeMessagingDuty> {
         trace!("Tracking incoming client message");
 
+        with_chaos!({
+            debug!("Chaos: Dropping incoming message");
+            return None;
+        });
+        
         let msg_id = msg.id();
+
 
         // We could have received a group decision containing a client msg,
         // before receiving the msg from that client directly.

--- a/src/node/elder_duties/key_section/client/client_msg_handling.rs
+++ b/src/node/elder_duties/key_section/client/client_msg_handling.rs
@@ -107,9 +107,8 @@ impl ClientMsgHandling {
             debug!("Chaos: Dropping incoming message");
             return None;
         });
-        
-        let msg_id = msg.id();
 
+        let msg_id = msg.id();
 
         // We could have received a group decision containing a client msg,
         // before receiving the msg from that client directly.

--- a/src/node/elder_duties/key_section/client/client_msg_handling.rs
+++ b/src/node/elder_duties/key_section/client/client_msg_handling.rs
@@ -10,6 +10,7 @@ pub use super::client_input_parse::{try_deserialize_handshake, try_deserialize_m
 pub use super::onboarding::Onboarding;
 use crate::node::node_ops::NodeMessagingDuty;
 use crate::utils;
+use crate::with_chaos;
 use crate::{Error, Result};
 use log::{error, info, trace, warn};
 use rand::{CryptoRng, Rng};
@@ -53,6 +54,12 @@ impl ClientMsgHandling {
     ) -> Result<()> {
         trace!("Processing client handshake");
         let mut the_stream = stream;
+
+        with_chaos!({
+            debug!("Chaos: Dropping handshake");
+            return Ok(());
+        });
+
         let result = self
             .onboarding
             .onboard_client(handshake, peer_addr, &mut the_stream, rng)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -88,7 +88,7 @@ impl Network {
                 .unwrap();
             nodes.push((command_tx, handle));
         }
-        thread::sleep(std::time::Duration::from_secs(30));
+        thread::sleep(std::time::Duration::from_secs(5));
         Self { nodes }
     }
 }


### PR DESCRIPTION
Add `with_chaos` macro to randomly perform actions (such as drop messages), to test for resilience.

Provides `SAFE_CHAOS_LEVEL` env var to configure the likelihood of chaos occuring. Where you can provide a value 1-100 to add more chaos.