### PR TITLE
chore(cd): add continuous delivery and auto merge dependabot PRs

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -1,0 +1,37 @@
+# auto merge workflow.
+#
+# Auto merge PR if commit msg begins with `chore(release):`,
+# or if it has been raised by Dependabot.
+# Uses https://github.com/ridedott/merge-me-action.
+
+name: Merge Version Change and Dependabot PRs automatically
+
+on: pull_request
+
+jobs:
+  merge:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: get commit message
+      run: |
+           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+    - name: show commit message
+      run : echo $commitmsg
+
+    - name: Merge Version change PR
+      if: startsWith( env.commitmsg, 'chore(release):')
+      uses: ridedott/merge-me-action@81667e6ae186ddbe6d3c3186d27d91afa7475e2c
+      with:
+        GITHUB_LOGIN: dirvine
+        GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        MERGE_METHOD: REBASE
+
+    - name: Dependabot Merge
+      uses: ridedott/merge-me-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MERGE_METHOD: REBASE

--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -18,7 +18,9 @@ jobs:
 
     - name: get commit message
       run: |
-           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+        commitmsg=$(git log --format=%s -n 1 ${{ github.event.pull_request.head.sha }})
+        echo "commitmsg=${commitmsg}" >> $GITHUB_ENV
+
     - name: show commit message
       run : echo $commitmsg
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,24 @@
+name: Version bump and create PR for changes
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-20.04
+    # Dont run if we're on a release commit
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump Version
+        uses: maidsafe/rust-version-bump-branch-creator@v2
+        with:
+          token: ${{ secrets.BRANCH_CREATOR_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,37 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # only if we have a tag
+    name: Release
+    runs-on: ubuntu-20.04
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - name: Set tag as env
+        shell: bash
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
+      - name: lets check tag
+        shell: bash
+        run: echo ${{ env.RELEASE_VERSION }}
+
+      - name: Generate Changelog
+        shell: bash
+        run: awk '/# \[/{c++;p=1}{if(c==2){exit}}p;' CHANGELOG.md > RELEASE-CHANGELOG.txt
+      - run: cat RELEASE-CHANGELOG.txt
+      - name: Release generation
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        with:
+          body_path: RELEASE-CHANGELOG.txt

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,5 +1,6 @@
 name: Create GitHub Release
 
+
 on:
   push:
     tags:
@@ -19,7 +20,7 @@ jobs:
 
       - name: Set tag as env
         shell: bash
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
 
       - name: lets check tag
         shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - master
-      - phase-2b
 
 env:
   # Run all cargo commands with --verbose.
@@ -225,38 +224,28 @@ jobs:
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 
-  # Not publishing to crates.io since the routing dependency points to a git repository.
-  # publish:
-  #   name: Publish
-  #   needs: deploy
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
-  #       with:
-  #         fetch-depth: '0'
-  #     # Is this a version change commit?
-  #     - shell: bash
-  #       id: commit_message
-  #       run: |
-  #         commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
-  #         echo "::set-output name=commit_message::$commit_message"
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
-  #       if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: login
-  #         args: ${{ secrets.CRATES_IO_TOKEN }}
-  #       if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: package
-  #       if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: publish
-  #       if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+  # Publish if we're on a release commit
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
+        with:
+          fetch-depth: '0'
+
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Publish to crates.io.
+      - name: Cargo Login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Cargo Publish
+        run: cargo publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -129,8 +129,27 @@ jobs:
           name: nodes-data
           path: nodes
 
+  # list any unused dependencies using cargo-udeps
+  cargo-udeps:
+    name: Unused dependency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      # Install and run cargo udeps to find unused cargo dependencies
+      - name: cargo-udeps duplicate dependency check
+        run: |
+          cargo install cargo-udeps --locked
+          cargo +nightly udeps --all-targets
+  
   # list all duplicate dependencies. Note that this does not error if duplicates found
-  dependencies:
+  duplicate-dependencies:
     name: List Duplicate Dependencies
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release  --features=simulated-payouts
+          args: --release  --features=simulated-payouts,client-tests
 
       - name: Upload node data on fail
         if: ${{ failure() }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,8 +45,7 @@ jobs:
 
       # Run Clippy.
       - name: Clippy checks
-        shell: bash
-        run: ./scripts/clippy
+        run: cargo clippy --all-targets
 
   coverage:
     name: Code coverage check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -146,3 +146,20 @@ jobs:
       # Run list duplicate dependencies script
       - shell: bash
         run: ./scripts/duplicate_dependency_check
+
+  # Test publish using --dry-run.
+  test-publish:
+    name: Test Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Test publish
+        run: cargo publish --dry-run

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release  --features=simulated-payouts,client-tests
+          args: --release  --features=simulated-payouts
 
       - name: Upload node data on fail
         if: ${{ failure() }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -20,11 +20,11 @@ jobs:
           with:
             fetch-depth: '0'
             token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
-        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        - run: echo "RELEASE_VERSION=$(git log -1 --pretty=%s)" >> $GITHUB_ENV
         # parse out non-tag text
-        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        - run: echo "RELEASE_VERSION=$( echo $RELEASE_VERSION | sed 's/chore(release)://' )" >> $GITHUB_ENV
         # remove spaces, but add back in `v` to tag, which is needed for standard-version
-        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo "RELEASE_VERSION=v$(echo $RELEASE_VERSION | tr -d '[:space:]')" >> $GITHUB_ENV
         - run: echo $RELEASE_VERSION
         - run: git tag $RELEASE_VERSION
 

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,37 @@
+name: Tag release commit
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+  GITHUB_TOKEN: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+
+jobs:
+  tag:
+      runs-on: ubuntu-latest
+      # Only run on a release commit
+      if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: '0'
+            token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        # parse out non-tag text
+        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        # remove spaces, but add back in `v` to tag, which is needed for standard-version
+        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo $RELEASE_VERSION
+        - run: git tag $RELEASE_VERSION
+
+        - name: Setup git for push
+          run: |
+            git remote add github "$REPO"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+        - name: Push tags to master
+          run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,310 +1,327 @@
 # Changelog
 
-## [0.24.0]
-- When a Node starts, start it as an Adult. Create the additional modules required only when it is promoted to an Elder.
-- Give Adults the responsibility of holding Immutable Data chunks.
-- Use routing's messaging API with signature accumulation for intra-section communication.
-- Implement chunk duplication if a node leaves the network. This will maintain the minimum number of copies required.
-- Update to the latest version of `quic-p2p` which enables automatic port forwarding using the IGD protocol.
-- Gracefully end the node process on SIGINT.
-- Use the latest version of `routing`.
-- Update to safe-nd 0.9.0 with refactored `Request` and `Response` enums.
-- Separate the Client Handler into smaller sub-modules.
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [0.23.0]
-- Enable required features in self-update dependency to support untar and unzip for packages
-- Add tarpaulin to GHA and push result to coveralls
-- Update to latest routing
+### [0.25.1](https://github.com/maidsafe/sn_node/compare/v0.25.0...v0.25.1) (2020-07-16)
+* fix/idata: make PUT request processing faster
 
-## [0.22.0]
-- Support a --update-only flag which only attempts to self-update binary
-- Update readme to link to contributing guidelines doc
-- Don't send client requests to PARSEC
-- Add dead_code on vote_for_action
-- Fix spacing bug for clippy
+### [0.25.0](https://github.com/maidsafe/sn_node/compare/0.24.0...v0.25.0) (2020-07-16)
+* feat/data: support for Sequence data type and associated requests.
+* feat/sequence: support for CRDT mutations on Sequence permissions and owner.
+* test/sequence: add integration test for Sequence operations.
+* feat/accumulator: collect BLS signatures in the vault to validate requests.
+* fix/duplication: fix bugs in duplication mechanism and clippy fixes.
+* fix/duplicaton: add the duplicated data to the holder list correctly.
+* test/integration: ignore put_immutable_data test.
+* fix/duplication: fix signature accumulation for duplication.
+* fix/log: Fix misleading vault message.
+* fix/idata: wait for all holders to process mutation requests.
 
-## [0.21.0]
-- improve app authorisation
-- introduce ParsecAction
-- complete indirection between vote and consensus
-- replace other payed action but login
-- add basic mock routing functions
-- send requests for deleting data via concensus
-- send create login packet requests to parsec
-- send transfer coins via consensus and rename
-- fix root_dir by using project's data dir by default
-- Send UpdateLoginPacket req via consensus
-- update to safe-nd 0.4.0
-- refactor test to verify granulated app permissions
-- allow to use multiple nodes for tests
-- add consensus votes on CreateBalance requests
-- send insert and delete auth keys request via…
-- change usage of idata term "kind" to "data"
-- introduce IDataRequest to eliminate unwraps
-- handle refunds when errors are returned from the data
-- deprecate Rpc::Refund to use Rpc::Response instead
-- test that refunds are processed
-- introduce util function to calculate refund and move
-- remove explicitly-listed non-warn lints
-- send CreateBalance request via consensus
-- add `phase-one` feature for updates
-- look up by message id
-- notify all connected instances of the client
-- Merge pull request #891 from ustulation/lookup-by-msg-id
-- integrate with Routing
-- fix clippy warnings and test failure
-- fix nikita's PR #888
-- Merge pull request #892 from ustulation/integrate-with-routing
-- forbid unsafe and add badge
-- use mock quic-p2p from routing
-- add --dump-completions flag similar to that of safe-cli
-- rename --dump-completions to --completions for consisten…
-- fix test case
-- fix smoke test failure.
-- make node rng seeded from routing's
-- Merge pull request #912 from maqi/use_same_rng
-- add caching and other changes to GHA
-- resolve non-producable issue
-- Merge pull request #914 from maqi/use_same_rng
-- support connection info requests from clients
-- support new handshake format
-- handle bootstrap request properly
-- bootstrap request fixes
-- update testing framework to new handshake format
-- Merge pull request #911 from octol/new-bootstrap-handshake-format
-- use real routing for the integration test
-- make client requests handled by node network
-- enable tests with feature of mock
-- Small tidy up of imports for routing API cleanup
-- fix clippy::needless_pass_by_value
-- Re-order use and pub use statements.
-- include path info in error strings
-- fixup/node: formatting
-- Merge pull request #919 from dirvine/vNext
-- Merge pull request #909 from dan-da/completions_pr
-- update routing dependecy
-- upgrade routing and avoid calling node poll test function
-- Merge pull request #924 from jeanphilippeD/upgade_routing_2
-- Use mock-quic-p2p crate instead of routing module
-- Enable test logging via pretty_env_logger
-- Enable reproducible tests
-- Remove pretty_env_logger dependency (use env_logger only)
-- Merge pull request #925 from madadam/mock-quic-p2p
-- Update codeowners
-- update to latest routing API
-- Merge pull request #928 from nbaksalyar/update-routing
-- remove refund for login packet exists errors
-- update to use routing exposed event mod
-- Update to latest routing
-- Update dependencies: routing, safe-nd and mock-quic-p2p
-- improve error message and avoid duplicate consensus
-- pull routing and qp2p with separate client channel
-- Merge pull request #939 from jeanphilippeD/client_channel
-- use latest version of self_update
-- Update version to 0.20.1
-- update routing and quic-p2p dependencies
-- support --log-dir arg to optionally log to a file instead o…
-- remove crate filter for logs, and make self-update to b…
-- Update to latest routing
-- run cargo update
+### [0.24.0] (2020-06-11)
+* When a Node starts, start it as an Adult. Create the additional modules required only when it is promoted to an Elder.
+* Give Adults the responsibility of holding Immutable Data chunks.
+* Use routing's messaging API with signature accumulation for intra-section communication.
+* Implement chunk duplication if a node leaves the network. This will maintain the minimum number of copies required.
+* Update to the latest version of `quic-p2p` which enables automatic port forwarding using the IGD protocol.
+* Gracefully end the node process on SIGINT.
+* Use the latest version of `routing`.
+* Update to safe-nd 0.9.0 with refactored `Request` and `Response` enums.
+* Separate the Client Handler into smaller sub-modules.
 
-## [0.20.1]
-- Set execution permission on safe_vault binary before packaging for release
+### [0.23.0]
+* Enable required features in self-update dependency to support untar and unzip for packages
+* Add tarpaulin to GHA and push result to coveralls
+* Update to latest routing
 
-## [0.20.0]
-- Return `AccessDenied` when apps request to insert, delete or list auth keys instead of ignoring the request.
-- Use project's data directory as the root directory.
-- Upgrade safe-nd dependency to 0.4.0. This includes granular permissions for applications.
-- Change usage of idata term "kind" to "data".
-- Introduce IDataRequest to eliminate unwraps.
-- Handle refunds when errors are returned from the data handlers.
-- Deprecate Rpc::Refund to use Rpc::Response instead.
-- Send response to the client that sent the request instead of all connected clients.
-- Use GitHub actions for build and release.
+### [0.22.0]
+* Support a --update-only flag which only attempts to self-update binary
+* Update readme to link to contributing guidelines doc
+* Don't send client requests to PARSEC
+* Add dead_code on vote_for_action
+* Fix spacing bug for clippy
 
-## [0.19.2]
-- This is a technical release without any changes from `0.19.1`.
+### [0.21.0]
+* improve app authorisation
+* introduce ParsecAction
+* complete indirection between vote and consensus
+* replace other payed action but login
+* add basic mock routing functions
+* send requests for deleting data via concensus
+* send create login packet requests to parsec
+* send transfer coins via consensus and rename
+* fix root_dir by using project's data dir by default
+* Send UpdateLoginPacket req via consensus
+* update to safe-nd 0.4.0
+* refactor test to verify granulated app permissions
+* allow to use multiple nodes for tests
+* add consensus votes on CreateBalance requests
+* send insert and delete auth keys request via…
+* change usage of idata term "kind" to "data"
+* introduce IDataRequest to eliminate unwraps
+* handle refunds when errors are returned from the data
+* deprecate Rpc::Refund to use Rpc::Response instead
+* test that refunds are processed
+* introduce util function to calculate refund and move
+* remove explicitly-listed non-warn lints
+* send CreateBalance request via consensus
+* add `phase-one` feature for updates
+* look up by message id
+* notify all connected instances of the client
+* Merge pull request #891 from ustulation/lookup-by-msg-id
+* integrate with Routing
+* fix clippy warnings and test failure
+* fix nikita's PR #888
+* Merge pull request #892 from ustulation/integrate-with-routing
+* forbid unsafe and add badge
+* use mock quic-p2p from routing
+* add --dump-completions flag similar to that of safe-cli
+* rename --dump-completions to --completions for consisten…
+* fix test case
+* fix smoke test failure.
+* make node rng seeded from routing's
+* Merge pull request #912 from maqi/use_same_rng
+* add caching and other changes to GHA
+* resolve non-producable issue
+* Merge pull request #914 from maqi/use_same_rng
+* support connection info requests from clients
+* support new handshake format
+* handle bootstrap request properly
+* bootstrap request fixes
+* update testing framework to new handshake format
+* Merge pull request #911 from octol/new-bootstrap-handshake-format
+* use real routing for the integration test
+* make client requests handled by node network
+* enable tests with feature of mock
+* Small tidy up of imports for routing API cleanup
+* fix clippy::needless_pass_by_value
+* Re-order use and pub use statements.
+* include path info in error strings
+* fixup/node: formatting
+* Merge pull request #919 from dirvine/vNext
+* Merge pull request #909 from dan-da/completions_pr
+* update routing dependecy
+* upgrade routing and avoid calling node poll test function
+* Merge pull request #924 from jeanphilippeD/upgade_routing_2
+* Use mock-quic-p2p crate instead of routing module
+* Enable test logging via pretty_env_logger
+* Enable reproducible tests
+* Remove pretty_env_logger dependency (use env_logger only)
+* Merge pull request #925 from madadam/mock-quic-p2p
+* Update codeowners
+* update to latest routing API
+* Merge pull request #928 from nbaksalyar/update-routing
+* remove refund for login packet exists errors
+* update to use routing exposed event mod
+* Update to latest routing
+* Update dependencies: routing, safe-nd and mock-quic-p2p
+* improve error message and avoid duplicate consensus
+* pull routing and qp2p with separate client channel
+* Merge pull request #939 from jeanphilippeD/client_channel
+* use latest version of self_update
+* Update version to 0.20.1
+* update routing and quic-p2p dependencies
+* support --log-dir arg to optionally log to a file instead o…
+* remove crate filter for logs, and make self-update to b…
+* Update to latest routing
+* run cargo update
 
-## [0.19.1]
-- Add `verbose` command line flag.
-- Fix the UX problem related to the self-update process (requiring to have a network connectivity even if a user just wanted to display the `--help` menu).
-- Improve the release process, adding `.zip` and `.tar.gz` packages to distribution.
+### [0.20.1]
+* Set execution permission on safe_vault binary before packaging for release
 
-## [0.19.0]
-- Rewrite the Vault code.
-- Support new data types (AppendOnlyData, unpublished sequenced/unsequenced MutableData, and unpublished ImmutableData).
-- Support coin operations.
-- Use quic-p2p for communication with clients.
-- Temporarily remove the Routing dependency.
-- Refactor the personas system into a new Vault architecture.
-- Use Rust stable / 2018 edition.
+### [0.20.0]
+* Return `AccessDenied` when apps request to insert, delete or list auth keys instead of ignoring the request.
+* Use project's data directory as the root directory.
+* Upgrade safe-nd dependency to 0.4.0. This includes granular permissions for applications.
+* Change usage of idata term "kind" to "data".
+* Introduce IDataRequest to eliminate unwraps.
+* Handle refunds when errors are returned from the data handlers.
+* Deprecate Rpc::Refund to use Rpc::Response instead.
+* Send response to the client that sent the request instead of all connected clients.
+* Use GitHub actions for build and release.
 
-## [0.18.0]
-- Improve Docker configuration scripts (thanks to @mattmccarty)
-- Use rust 1.22.1 stable / 2017-11-23 nightly
-- rustfmt 0.9.0 and clippy-0.0.174
+### [0.19.2]
+* This is a technical release without any changes from `0.19.1`.
 
-## [0.17.2]
-- Update dependencies.
+### [0.19.1]
+* Add `verbose` command line flag.
+* Fix the UX problem related to the self-update process (requiring to have a network connectivity even if a user just wanted to display the `--help` menu).
+* Improve the release process, adding `.zip` and `.tar.gz` packages to distribution.
 
-## [0.17.1]
-- Change test to use value of MAX_MUTABLE_DATA_ENTRIES rather than magic numbers.
+### [0.19.0]
+* Rewrite the Vault code.
+* Support new data types (AppendOnlyData, unpublished sequenced/unsequenced MutableData, and unpublished ImmutableData).
+* Support coin operations.
+* Use quic-p2p for communication with clients.
+* Temporarily remove the Routing dependency.
+* Refactor the personas system into a new Vault architecture.
+* Use Rust stable / 2018 edition.
 
-## [0.17.0]
-- Remove proxy rate exceed event.
+### [0.18.0]
+* Improve Docker configuration scripts (thanks to @mattmccarty)
+* Use rust 1.22.1 stable / 2017-11-23 nightly
+* rustfmt 0.9.0 and clippy-0.0.174
 
-## [0.16.1-2]
-- Update to use Routing 0.32.2.
+### [0.17.2]
+* Update dependencies.
 
-## [0.16.0]
-- Use Routing definitions for group size and quorum.
-- Add dev config options to allow running a local testnet.
-- Update to use Routing 0.32.0.
-- Update to use Rust Stable 1.19.0 / Nightly 2017-07-20, Clippy 0.0.144, and rustfmt 0.9.0.
-- Improve DataManager tests.
+### [0.17.1]
+* Change test to use value of MAX_MUTABLE_DATA_ENTRIES rather than magic numbers.
 
-## [0.15.0]
-- Deprecate and remove support for Structured, PrivAppendable and PubAppendable Data.
-- Add support for MutableData instead.
-- MaidManagers only charge on put success now.
-- MaidManagers charge by directly storing the MsgIds and counting the number of them to determine the account balance.
-- MaidManagers support insertion and deletion of auth-keys to support auth-app paradigm in which all mutations on behalf of the owner of the account has to go via the MaidManagers.
+### [0.17.0]
+* Remove proxy rate exceed event.
 
-## [0.14.0]
-- Upgrade to routing 0.28.5.
-- Migrate from rustc-serialize to serde.
-- Migrate from docopt to clap.
-- Implement invitation-based account creation.
+### [0.16.1-2]
+* Update to use Routing 0.32.2.
 
-## [0.13.2]
-- Upgrade to routing 0.28.4.
+### [0.16.0]
+* Use Routing definitions for group size and quorum.
+* Add dev config options to allow running a local testnet.
+* Update to use Routing 0.32.0.
+* Update to use Rust Stable 1.19.0 / Nightly 2017-07-20, Clippy 0.0.144, and rustfmt 0.9.0.
+* Improve DataManager tests.
 
-## [0.13.1]
-- Upgrade to routing 0.28.2.
+### [0.15.0]
+* Deprecate and remove support for Structured, PrivAppendable and PubAppendable Data.
+* Add support for MutableData instead.
+* MaidManagers only charge on put success now.
+* MaidManagers charge by directly storing the MsgIds and counting the number of them to determine the account balance.
+* MaidManagers support insertion and deletion of auth-keys to support auth-app paradigm in which all mutations on behalf of the owner of the account has to go via the MaidManagers.
 
-## [0.13.0]
-- Migrate to routing 0.28.0.
-- Use a single event loop for routing and safe_vault.
-- Fix issues with account creation and data requests.
+### [0.14.0]
+* Upgrade to routing 0.28.5.
+* Migrate from rustc-serialize to serde.
+* Migrate from docopt to clap.
+* Implement invitation-based account creation.
 
-## [0.12.1]
-- Enforce data size caps.
-- Enable new delete mechanism.
+### [0.13.2]
+* Upgrade to routing 0.28.4.
 
-## [0.12.0]
-- Handle appendable data types in data manager.
-- Fix a synchronisation problem in Put/Post handling.
+### [0.13.1]
+* Upgrade to routing 0.28.2.
 
-## [0.11.0]
-- Use rust_sodium instead of sodiumoxide.
-- Upgrade to routing 0.23.4, with merged safe_network_common.
+### [0.13.0]
+* Migrate to routing 0.28.0.
+* Use a single event loop for routing and safe_vault.
+* Fix issues with account creation and data requests.
 
-## [0.10.6]
-- Revert to routing 0.23.3.
+### [0.12.1]
+* Enforce data size caps.
+* Enable new delete mechanism.
 
-## [0.10.5]
-- Update the crate documentation.
-- Upgrade to routing 0.25.0.
+### [0.12.0]
+* Handle appendable data types in data manager.
+* Fix a synchronisation problem in Put/Post handling.
 
-## [0.10.4]
-- Remove spammy trace statement.
+### [0.11.0]
+* Use rust_sodium instead of sodiumoxide.
+* Upgrade to routing 0.23.4, with merged safe_network_common.
 
-## [0.10.3]
-- Set default Put limit to 500 and default chunk store limit to 2 GB.
+### [0.10.6]
+* Revert to routing 0.23.3.
 
-## [0.10.2]
-- Prevent vaults from removing existing chunk_store when terminating.
+### [0.10.5]
+* Update the crate documentation.
+* Upgrade to routing 0.25.0.
 
-## [0.10.1]
-- Fix chunk store directory handling.
-- Remove remaining uses of the thread-local random number generator to make
+### [0.10.4]
+* Remove spammy trace statement.
+
+### [0.10.3]
+* Set default Put limit to 500 and default chunk store limit to 2 GB.
+
+### [0.10.2]
+* Prevent vaults from removing existing chunk_store when terminating.
+
+### [0.10.1]
+* Fix chunk store directory handling.
+* Remove remaining uses of the thread-local random number generator to make
   tests deterministic.
-- Make data manager statistics less verbose to reduce spam in the logs.
+* Make data manager statistics less verbose to reduce spam in the logs.
 
-## [0.10.0]
-- Merge chunk_store into safe_vault and make its root directory configurable.
-- Implement caching for immutable data.
+### [0.10.0]
+* Merge chunk_store into safe_vault and make its root directory configurable.
+* Implement caching for immutable data.
 
-## [0.9.0]
-- Migrate to the mio-based Crust and the new Routing Request/Response API.
-- Handle `GetAccountInfo` requests to provide information about a client's used
+### [0.9.0]
+* Migrate to the mio-based Crust and the new Routing Request/Response API.
+* Handle `GetAccountInfo` requests to provide information about a client's used
   and remaining chunk count.
 
-## [0.8.1]
-- Allow passing `--first` via command line to start the first Vault of a new network.
-- Updated dependencies.
+### [0.8.1]
+* Allow passing `--first` via command line to start the first Vault of a new network.
+* Updated dependencies.
 
-## [0.8.0]
-- Several tweaks to churn handling in data_manager.
-- Implement process to automatically build release binaries.
-- Re-organise the tests to use mock Crust instead of mock Routing.
-- Improve logging.
-- Fix several bugs.
+### [0.8.0]
+* Several tweaks to churn handling in data_manager.
+* Implement process to automatically build release binaries.
+* Re-organise the tests to use mock Crust instead of mock Routing.
+* Improve logging.
+* Fix several bugs.
 
-## [0.7.0]
-- Restart routing if it failed to join the network.
-- Reimplement the refresh algorithm for structured and immutable data to make it
+### [0.7.0]
+* Restart routing if it failed to join the network.
+* Reimplement the refresh algorithm for structured and immutable data to make it
   less wasteful and more reliable.
 
-## [0.6.0]
-- Major change of persona strategy regarding `ImmutableData` (removal of three personas)
-- Major refactoring of integration tests (uses mock Crust feature)
-- Default test runner to unit tests (previously run using the mock Routing feature)
+### [0.6.0]
+* Major change of persona strategy regarding `ImmutableData` (removal of three personas)
+* Major refactoring of integration tests (uses mock Crust feature)
+* Default test runner to unit tests (previously run using the mock Routing feature)
 
-## [0.5.0]
-- Replaced use of local Client errors for those in safe_network_common
-- Swapped dependency on mpid_messaging crate for safe_network_common dependency
-- Removed Mpid tests from CI suite
-- Updated some message flows
-- Completed churn-handling for ImmutableDataManager
-- Added many unit tests
-- Fixed Clippy warnings
-- Several bugfixes
+### [0.5.0]
+* Replaced use of local Client errors for those in safe_network_common
+* Swapped dependency on mpid_messaging crate for safe_network_common dependency
+* Removed Mpid tests from CI suite
+* Updated some message flows
+* Completed churn-handling for ImmutableDataManager
+* Added many unit tests
+* Fixed Clippy warnings
+* Several bugfixes
 
-## [0.4.0]
-- Accommodated updates to dependencies' APIs
-- Ensured that the network can correctly handle Clients doing a Get for ImmutableData immediately after doing a Put
-- Reduced `REPLICANTS` and `MIN_REPLICANTS` to 4
+### [0.4.0]
+* Accommodated updates to dependencies' APIs
+* Ensured that the network can correctly handle Clients doing a Get for ImmutableData immediately after doing a Put
+* Reduced `REPLICANTS` and `MIN_REPLICANTS` to 4
 
-## [0.3.0]
-- Major refactor to accommodate changed Routing
+### [0.3.0]
+* Major refactor to accommodate changed Routing
 
-## [0.1.6]
-- Default to use real Routing rather than the mock
-- Updated config file to match Crust changes
-- Refactored flow for put_response
-- Added churn tests
-- Refactored returns from most persona functions to not use Result
+### [0.1.6]
+* Default to use real Routing rather than the mock
+* Updated config file to match Crust changes
+* Refactored flow for put_response
+* Added churn tests
+* Refactored returns from most persona functions to not use Result
 
-## [0.1.5]
-- Major refactor of production code and tests to match Routing's new API, allowing testing on a real network rather than a mock
-- Updated installers to match Crust's config/bootstrap file changes
-- Added tarball to packages being generated
-- Dropped usage of feature-gated items
+### [0.1.5]
+* Major refactor of production code and tests to match Routing's new API, allowing testing on a real network rather than a mock
+* Updated installers to match Crust's config/bootstrap file changes
+* Added tarball to packages being generated
+* Dropped usage of feature-gated items
 
-## [0.1.4]
-- [MAID-1283](https://maidsafe.atlassian.net/browse/MAID-1283) Rename repositories from "maidsafe_" to "safe_"
+### [0.1.4]
+* [MAID-1283](https://maidsafe.atlassian.net/browse/MAID-1283) Rename repositories from "maidsafe_" to "safe_"
 
-## [0.1.3]
-- [MAID-1186](https://maidsafe.atlassian.net/browse/MAID-1186) Handling of unified Structrued Data
+### [0.1.3]
+* [MAID-1186](https://maidsafe.atlassian.net/browse/MAID-1186) Handling of unified Structrued Data
     - [MAID-1187](https://maidsafe.atlassian.net/browse/MAID-1187) Updating Version Handler
     - [MAID-1188](https://maidsafe.atlassian.net/browse/MAID-1188) Updating other personas if required
 
-## [0.1.2] - code clean up
-- [MAID 1185](https://maidsafe.atlassian.net/browse/MAID-1185) using unwrap unsafely
+### [0.1.2] - code clean up
+* [MAID 1185](https://maidsafe.atlassian.net/browse/MAID-1185) using unwrap unsafely
 
-## [0.1.1]
-- Updated dependencies' versions
-- Fixed lint warnings caused by latest Rust nightly
-- [Issue 117](https://github.com/maidsafe/safe_vault/issues/117) meaningful type_tag
-- [PR 124](https://github.com/maidsafe/safe_vault/pull/124) integration test with client
+### [0.1.1]
+* Updated dependencies' versions
+* Fixed lint warnings caused by latest Rust nightly
+* [Issue 117](https://github.com/maidsafe/safe_vault/issues/117) meaningful type_tag
+* [PR 124](https://github.com/maidsafe/safe_vault/pull/124) integration test with client
     - client log in / log out
     - complete put flow
     - complete get flow
 
-## [0.1.0] - integrate with routing and safecoin farming initial work [rust-2 Sprint]
-- [MAID-1107](https://maidsafe.atlassian.net/browse/MAID-1107) Rename actions (changes in routing v0.1.60)
-- [MAID-1008](https://maidsafe.atlassian.net/browse/MAID-1008) Documentation
+### [0.1.0] - integrate with routing and safecoin farming initial work [rust-2 Sprint]
+* [MAID-1107](https://maidsafe.atlassian.net/browse/MAID-1107) Rename actions (changes in routing v0.1.60)
+* [MAID-1008](https://maidsafe.atlassian.net/browse/MAID-1008) Documentation
     - [MAID-1009](https://maidsafe.atlassian.net/browse/MAID-1009) Personas
         - ClientManager : MaidManager
         - NodeManager : PmidManager
@@ -317,33 +334,33 @@
         - PutData / PutResponse
         - GetData / GetResponse
         - PostData
-- [MAID-1013](https://maidsafe.atlassian.net/browse/MAID-1013) Complete unfinished code (if it will be covered by the later-on tasks in this sprint, explicitly mention it as in-code TODO comment), especially in vault.rs
+* [MAID-1013](https://maidsafe.atlassian.net/browse/MAID-1013) Complete unfinished code (if it will be covered by the later-on tasks in this sprint, explicitly mention it as in-code TODO comment), especially in vault.rs
     - [MAID-1109](https://maidsafe.atlassian.net/browse/MAID-1109) handle_get_key
     - [MAID-1112](https://maidsafe.atlassian.net/browse/MAID-1112) handle_put_response
     - [MAID-1113](https://maidsafe.atlassian.net/browse/MAID-1113) handle_cache_get
     - [MAID-1113](https://maidsafe.atlassian.net/browse/MAID-1113) handle_cache_put
-- [MAID-1014](https://maidsafe.atlassian.net/browse/MAID-1014) Integration test with new routing and crust (vaults bootstrap and network setup)
+* [MAID-1014](https://maidsafe.atlassian.net/browse/MAID-1014) Integration test with new routing and crust (vaults bootstrap and network setup)
     - [MAID-1028](https://maidsafe.atlassian.net/browse/MAID-1028) local joining test (process counting)
     - [MAID-1016](https://maidsafe.atlassian.net/browse/MAID-1016) network example (nodes populating)
-- [MAID-1012](https://maidsafe.atlassian.net/browse/MAID-1012) SafeCoin farming (new persona may need to be introduced, the task needs to be ‘expandable’ ) documentation
+* [MAID-1012](https://maidsafe.atlassian.net/browse/MAID-1012) SafeCoin farming (new persona may need to be introduced, the task needs to be ‘expandable’ ) documentation
     - farming
     - account
-- [MAID-1021](https://maidsafe.atlassian.net/browse/MAID-1021) Implement handling for Safecoin farming rate
+* [MAID-1021](https://maidsafe.atlassian.net/browse/MAID-1021) Implement handling for Safecoin farming rate
     - Farming rate determined by the Sacrificial copies.
     - Farming rate drops when more copies are available and rises when less copies are available.
 
-## [0.0.0 - 0.0.3]
-- VaultFacade initial implementation
-- Chunkstore implementation and test
-- Initial Persona implementation :
+### [0.0.0 - 0.0.3]
+* VaultFacade initial implementation
+* Chunkstore implementation and test
+* Initial Persona implementation :
     - Implement MaidManager and test
     - Implement DataManager and test
     - Implement PmidManager and test
     - Implement PmidNode and test
     - Implement VersionHandler
-- Flow related work :
+* Flow related work :
     - Complete simple Put flow and test
     - Complete simple Get flow and test
     - Complete Create Maid Account Flow
-- Installers (linux deb/rpm 32/64 bit, Windows 32 / 64. OSX)
-- Coverage analysis
+* Installers (linux deb/rpm 32/64 bit, Windows 32 / 64. OSX)
+* Coverage analysis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "sn_client"
 version = "0.42.1"
-source = "git+https://github.com/maidsafe/sn_client#cf4db2c465aade7ab45443758bd2ae0ebc2a5ed9"
+source = "git+https://github.com/maidsafe/sn_client#42997504b1a68cacd1d568ece1c3ef6fae9bfe57"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2643,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "sn_data_types"
-version = "0.11.32"
+version = "0.11.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13919752c9fd2f92f09964619dc47348b35b93c917854455425f8baa14c5779"
+checksum = "42b794b17824654e79cc411c37b1490e236b2a2a4bb24a6dbed645df915b6c47"
 dependencies = [
  "bincode",
  "crdts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,16 +620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
-dependencies = [
- "nix",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,18 +1689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
- "libc",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,15 +2642,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sn_fake_clock"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9905409773adfa18bd77c51123f451b349ba12bd3ecaef78fb344576bab890ed"
-
-[[package]]
 name = "sn_launch_tool"
-version = "0.0.4"
-source = "git+https://github.com/maidsafe/sn_launch_tool.git#924e089c0a155d92e636c001e93a5e2baf535bcc"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5207f56d56ec0590437060aa074f6b26bd670b41de49b8a493e04e6b4224cc"
 dependencies = [
  "directories 2.0.2",
  "env_logger 0.7.1",
@@ -2691,7 +2664,6 @@ dependencies = [
  "bytes 0.5.6",
  "crdts",
  "crossbeam-channel",
- "ctrlc",
  "dirs-next 1.0.2",
  "ed25519",
  "ed25519-dalek",
@@ -2714,7 +2686,6 @@ dependencies = [
  "signature",
  "sn_client",
  "sn_data_types",
- "sn_fake_clock",
  "sn_launch_tool",
  "sn_routing",
  "sn_transfers",
@@ -2729,8 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "sn_routing"
-version = "0.37.0"
-source = "git+https://github.com/yoga07/sn_routing?branch=start-up#80eea9b03661245177380a4db70c0c5f270369c0"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc028836322b8a344485995bbb833d57ac2a77c3a20a42929d18ff67324d6b00"
 dependencies = [
  "bincode",
  "bls_dkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ xor_name = "1.1.0"
 sn_launch_tool = { git = "https://github.com/maidsafe/sn_launch_tool.git" }
 
 [dev_dependencies]
-sn_client = { git = "https://github.com/maidsafe/sn_client"}
+sn_client = { git = "https://github.com/maidsafe/sn_client", features=["simulated-payouts"]}
 maplit = "1.0.1"
 tempdir = "~0.3.7"
 tokio = { version="~0.2.21", features=["rt-core", "blocking", "stream", "rt-util", "rt-threaded"] }
@@ -63,7 +63,6 @@ doc = false
 
 [features]
 simulated-payouts = ["sn_data_types/simulated-payouts", "sn_transfers/simulated-payouts"]
-client-tests = ["simulated-payouts", "sn_client/simulated-payouts"]
 chaos = []
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ name = "sn_node"
 doc = false
 
 [features]
+default = ["simulated-payouts"]
 simulated-payouts = ["sn_data_types/simulated-payouts", "sn_transfers/simulated-payouts"]
 chaos = []
 
@@ -68,4 +69,4 @@ crdts = { git = "https://github.com/joshuef/rust-crdt", branch="Remove-Lseqdefau
 # sn_data_types = {path="../sn_data_types"}
 
 [package.metadata.cargo-udeps.ignore]
-development = ["sn_client"]
+development = ["sn_client", "maplit"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ base64 = "~0.10.1"
 bincode = "1.2.1"
 bytes = { version = "~0.5.4", features = ["serde"] }
 crossbeam-channel = "~0.4.2"
-ctrlc = "3.1.3"
 dirs-next = "1.0.1"
-sn_fake_clock = "~0.4.0"
 flexi_logger = "~0.16.1"
 futures = "~0.3.5"
 fxhash = { version = "~0.2.1", optional = true }
@@ -31,7 +29,7 @@ pickledb = "~0.4.0"
 quick-error = "1.2.2"
 rand = "~0.7.3"
 rand_chacha = "~0.2.2"
-sn_routing = { git = "https://github.com/yoga07/sn_routing", branch = "start-up" }
+sn_routing = "~0.38.0"
 self_update = { version = "~0.16.0", default-features = false, features = ["rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"] }
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_json = "1.0.53"
@@ -48,7 +46,7 @@ ed25519 = "1.0.1"
 signature = "1.1.0"
 tokio = { version = "~0.2.5", features = ["macros", "fs", "sync"] }
 xor_name = "1.1.0"
-sn_launch_tool = { git = "https://github.com/maidsafe/sn_launch_tool.git" }
+sn_launch_tool = "~0.0.5"
 
 [dev_dependencies]
 sn_client = { git = "https://github.com/maidsafe/sn_client", features=["simulated-payouts"]}
@@ -68,3 +66,6 @@ chaos = []
 [patch.crates-io]
 crdts = { git = "https://github.com/joshuef/rust-crdt", branch="Remove-LseqdefaultApply" }
 # sn_data_types = {path="../sn_data_types"}
+
+[package.metadata.cargo-udeps.ignore]
+development = ["sn_client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ xor_name = "1.1.0"
 sn_launch_tool = { git = "https://github.com/maidsafe/sn_launch_tool.git" }
 
 [dev_dependencies]
+sn_client = { git = "https://github.com/maidsafe/sn_client"}
 maplit = "1.0.1"
 tempdir = "~0.3.7"
-sn_client = { git = "https://github.com/maidsafe/sn_client" }
 tokio = { version="~0.2.21", features=["rt-core", "blocking", "stream", "rt-util", "rt-threaded"] }
 futures = "~0.3.5"
 
@@ -62,8 +62,10 @@ name = "sn_node"
 doc = false
 
 [features]
-simulated-payouts = ["sn_data_types/simulated-payouts", "sn_transfers/simulated-payouts", "sn_client/simulated-payouts"]
+simulated-payouts = ["sn_data_types/simulated-payouts", "sn_transfers/simulated-payouts"]
+client-tests = ["simulated-payouts", "sn_client/simulated-payouts"]
 chaos = []
 
 [patch.crates-io]
 crdts = { git = "https://github.com/joshuef/rust-crdt", branch="Remove-LseqdefaultApply" }
+# sn_data_types = {path="../sn_data_types"}

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e -x
-
-RUSTFLAGS="-D warnings" cargo clippy "$@" --all-targets

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+// ------------- Client Tests -----------------
+// --------------------------------------------
 use super::Network;
 use sn_client::client::{
     exported_tests as client_tests, map_apis::exported_tests as map_tests,
@@ -26,181 +28,182 @@ fn start_network() {
 }
 
 // --------------------------------------------
-// ------------- Client Tests -----------------
-// --------------------------------------------
+#[cfg(feature = "client-tests")]
+mod test {
+    use super::*;
+    #[tokio::test]
+    async fn client_creation() {
+        start_network();
+        assert!(client_tests::client_creation().await.is_ok());
+    }
 
-#[tokio::test]
-async fn client_creation() {
-    start_network();
-    assert!(client_tests::client_creation().await.is_ok());
-}
-
-#[tokio::test]
-async fn client_creation_for_existing_sk() {
-    start_network();
-    assert!(client_tests::client_creation_with_existing_keypair()
-        .await
-        .is_ok());
-}
-
-// --------------------------------------------
-// --------- Transfer Actor Tests -------------
-// --------------------------------------------
-
-#[tokio::test]
-async fn transfer_actor_creation_hydration_for_nonexistant_balance() {
-    start_network();
-    assert!(
-        transfer_actor_tests::transfer_actor_creation_hydration_for_nonexistant_balance()
+    #[tokio::test]
+    async fn client_creation_for_existing_sk() {
+        start_network();
+        assert!(client_tests::client_creation_with_existing_keypair()
             .await
-            .is_ok()
-    );
-}
+            .is_ok());
+    }
 
-#[tokio::test]
-async fn transfer_actor_creation_hydration_for_existing_balance() {
-    start_network();
-    assert!(
-        transfer_actor_tests::transfer_actor_creation_hydration_for_existing_balance()
+    // --------------------------------------------
+    // --------- Transfer Actor Tests -------------
+    // --------------------------------------------
+
+    #[tokio::test]
+    async fn transfer_actor_creation_hydration_for_nonexistant_balance() {
+        start_network();
+        assert!(
+            transfer_actor_tests::transfer_actor_creation_hydration_for_nonexistant_balance()
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn transfer_actor_creation_hydration_for_existing_balance() {
+        start_network();
+        assert!(
+            transfer_actor_tests::transfer_actor_creation_hydration_for_existing_balance()
+                .await
+                .is_ok()
+        );
+    }
+
+    // --------------------------------------------
+    // ------------ Transfer Tests ----------------
+    // --------------------------------------------
+
+    #[tokio::test]
+    async fn cannot_write_with_insufficient_balance() {
+        start_network();
+        assert!(transfer_tests::cannot_write_with_insufficient_balance()
             .await
-            .is_ok()
-    );
-}
+            .is_ok());
+    }
 
-// --------------------------------------------
-// ------------ Transfer Tests ----------------
-// --------------------------------------------
-
-#[tokio::test]
-async fn cannot_write_with_insufficient_balance() {
-    start_network();
-    assert!(transfer_tests::cannot_write_with_insufficient_balance()
-        .await
-        .is_ok());
-}
-
-#[tokio::test]
-async fn insufficient_balance_transfers() {
-    start_network();
-    assert!(transfer_tests::insufficient_balance_transfers()
-        .await
-        .is_ok());
-}
-
-#[tokio::test]
-async fn transfer_actor_cannot_send_0_money_req() {
-    start_network();
-    assert!(transfer_tests::transfer_actor_cannot_send_0_money_req()
-        .await
-        .is_ok());
-}
-
-#[tokio::test]
-async fn transfer_actor_can_send_several_transfers_and_thats_reflected_locally() {
-    start_network();
-    assert!(
-        transfer_tests::transfer_actor_can_send_several_transfers_and_thats_reflected_locally()
+    #[tokio::test]
+    async fn insufficient_balance_transfers() {
+        start_network();
+        assert!(transfer_tests::insufficient_balance_transfers()
             .await
-            .is_ok()
-    );
-}
+            .is_ok());
+    }
 
-#[tokio::test]
-async fn transfer_actor_can_send_money_and_thats_reflected_locally() {
-    start_network();
-    assert!(
-        transfer_tests::transfer_actor_can_send_money_and_thats_reflected_locally()
+    #[tokio::test]
+    async fn transfer_actor_cannot_send_0_money_req() {
+        start_network();
+        assert!(transfer_tests::transfer_actor_cannot_send_0_money_req()
             .await
-            .is_ok()
-    );
-}
+            .is_ok());
+    }
 
-#[tokio::test]
-async fn balance_transfers_between_clients() {
-    start_network();
-    assert!(transfer_tests::balance_transfers_between_clients()
-        .await
-        .is_ok());
-}
+    #[tokio::test]
+    async fn transfer_actor_can_send_several_transfers_and_thats_reflected_locally() {
+        start_network();
+        assert!(
+            transfer_tests::transfer_actor_can_send_several_transfers_and_thats_reflected_locally()
+                .await
+                .is_ok()
+        );
+    }
 
-// --------------------------------------------
-// ---------- Sequence Data Tests -------------
-// --------------------------------------------
+    #[tokio::test]
+    async fn transfer_actor_can_send_money_and_thats_reflected_locally() {
+        start_network();
+        assert!(
+            transfer_tests::transfer_actor_can_send_money_and_thats_reflected_locally()
+                .await
+                .is_ok()
+        );
+    }
 
-#[tokio::test]
-async fn append_to_sequence_test() {
-    start_network();
-    assert!(sequence_tests::append_to_sequence_test().await.is_ok());
-}
-
-#[tokio::test]
-async fn sequence_basics_test() {
-    start_network();
-    assert!(sequence_tests::sequence_basics_test().await.is_ok());
-}
-
-#[tokio::test]
-async fn sequence_cannot_delete_public_test() {
-    start_network();
-    assert!(sequence_tests::sequence_cannot_delete_public_test()
-        .await
-        .is_ok());
-}
-
-#[tokio::test]
-async fn sequence_deletions_should_cost_put_price() {
-    start_network();
-    assert!(sequence_tests::sequence_deletions_should_cost_put_price()
-        .await
-        .is_ok());
-}
-
-#[tokio::test]
-async fn sequence_private_permissions_test() {
-    start_network();
-    assert!(sequence_tests::sequence_private_permissions_test()
-        .await
-        .is_ok());
-}
-
-#[tokio::test]
-async fn sequence_pub_permissions_test() {
-    start_network();
-    assert!(sequence_tests::sequence_pub_permissions_test()
-        .await
-        .is_ok());
-}
-
-// --------------------------------------------
-// ------------ Map Data Tests ----------------
-// --------------------------------------------
-
-#[tokio::test]
-async fn del_seq_map_test() {
-    start_network();
-    assert!(map_tests::del_seq_map_test().await.is_ok());
-}
-
-#[tokio::test]
-async fn map_cannot_initially_put_data_with_another_owner_than_current_client() {
-    start_network();
-    assert!(
-        map_tests::map_cannot_initially_put_data_with_another_owner_than_current_client()
+    #[tokio::test]
+    async fn balance_transfers_between_clients() {
+        start_network();
+        assert!(transfer_tests::balance_transfers_between_clients()
             .await
-            .is_ok()
-    );
-}
+            .is_ok());
+    }
 
-#[tokio::test]
-async fn del_unseq_map_test() {
-    start_network();
-    assert!(map_tests::del_unseq_map_test().await.is_ok());
-}
+    // --------------------------------------------
+    // ---------- Sequence Data Tests -------------
+    // --------------------------------------------
 
-#[tokio::test]
-async fn map_deletions_should_cost_put_price() {
-    start_network();
-    assert!(map_tests::map_deletions_should_cost_put_price()
-        .await
-        .is_ok());
+    #[tokio::test]
+    async fn append_to_sequence_test() {
+        start_network();
+        assert!(sequence_tests::append_to_sequence_test().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sequence_basics_test() {
+        start_network();
+        assert!(sequence_tests::sequence_basics_test().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sequence_cannot_delete_public_test() {
+        start_network();
+        assert!(sequence_tests::sequence_cannot_delete_public_test()
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn sequence_deletions_should_cost_put_price() {
+        start_network();
+        assert!(sequence_tests::sequence_deletions_should_cost_put_price()
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn sequence_private_permissions_test() {
+        start_network();
+        assert!(sequence_tests::sequence_private_permissions_test()
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn sequence_pub_permissions_test() {
+        start_network();
+        assert!(sequence_tests::sequence_pub_permissions_test()
+            .await
+            .is_ok());
+    }
+
+    // --------------------------------------------
+    // ------------ Map Data Tests ----------------
+    // --------------------------------------------
+
+    #[tokio::test]
+    async fn del_seq_map_test() {
+        start_network();
+        assert!(map_tests::del_seq_map_test().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn map_cannot_initially_put_data_with_another_owner_than_current_client() {
+        start_network();
+        assert!(
+            map_tests::map_cannot_initially_put_data_with_another_owner_than_current_client()
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn del_unseq_map_test() {
+        start_network();
+        assert!(map_tests::del_unseq_map_test().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn map_deletions_should_cost_put_price() {
+        start_network();
+        assert!(map_tests::map_deletions_should_cost_put_price()
+            .await
+            .is_ok());
+    }
 }

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -28,7 +28,7 @@ fn start_network() {
 }
 
 // --------------------------------------------
-#[cfg(feature = "client-tests")]
+#[cfg(feature = "simulated-payouts")]
 mod test {
     use super::*;
     #[tokio::test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -90,7 +90,7 @@ impl Network {
                 .unwrap();
             nodes.push((command_tx, handle));
         }
-        thread::sleep(std::time::Duration::from_secs(80));
+        thread::sleep(std::time::Duration::from_secs(30));
         Self { nodes }
     }
 }


### PR DESCRIPTION
Implement a CD process where any PR merged to master will
automatically trigger a crate publish, a tag, a 'chore(release):'
PR which is auto merged, and a GitHub release.
This PR also adds auto merging for dependabot PRs which pass CI.
This PR also reformats the changelog to match the newly auto-
generated format.

Also added cargo udeps scan to PR CI which flagged up3 seemingly unused deps: ctrlc, sn_fake_clock and maplit. Removed them from Cargo.toml.

Added `Do not merge` flag as merging this will result in a release/publish - crate should be considered stable before we merge.