### PR TITLE
chore(cd): update cd pipeline to look for `chore(release)`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,7 +3,7 @@
 # Runs when a PR has been merged to the master branch.
 #
 # 1. Generates a release build.
-# 2. If the last commit is a version change, publish.
+# 2. If the last commit is a chore(release), publish.
 
 name: Master
 
@@ -147,10 +147,10 @@ jobs:
         run: chmod -R +x artifacts/prod
       - shell: bash
         run: make package-commit_hash-artifacts-for-deploy
-        if: "!startsWith(steps.commit_message.outputs.commit_message, 'Version change')"
+        if: "!startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')"
       - shell: bash
         run: make package-version-artifacts-for-deploy
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
 
       # Get release description (requires generated archives)
       - shell: bash
@@ -161,7 +161,7 @@ jobs:
           description="${description//$'\n'/'%0A'}"
           description="${description//$'\r'/'%0D'}"
           echo "::set-output name=description::$description"
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
 
       # Upload all the release archives to S3
       - name: Upload archives to S3
@@ -176,7 +176,7 @@ jobs:
           draft: false
           prerelease: false
           body: ${{ steps.release_description.outputs.description }}
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
 
       # Upload zip files
       - uses: actions/upload-release-asset@v1.0.1
@@ -185,21 +185,21 @@ jobs:
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
           asset_content_type: application/zip
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
           asset_content_type: application/zip
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
           asset_content_type: application/zip
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
 
       # Upload tar files
       - uses: actions/upload-release-asset@v1.0.1
@@ -208,21 +208,21 @@ jobs:
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
           asset_content_type: application/zip
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
           asset_content_type: application/zip
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        if: startsWith(steps.commit_message.outputs.commit_message, 'chore(release)')
 
   # Publish if we're on a release commit
   publish:
@@ -248,4 +248,4 @@ jobs:
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
 
       - name: Cargo Publish
-        run: cargo publish
+        run: cargo publish --allow-dirty

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -180,4 +180,4 @@ jobs:
           override: true
 
       - name: Test publish
-        run: cargo publish --dry-run
+        run: cargo publish --allow-dirty --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,7 +2583,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "sn_client"
 version = "0.42.1"
-source = "git+https://github.com/maidsafe/sn_client#42997504b1a68cacd1d568ece1c3ef6fae9bfe57"
+source = "git+https://github.com/maidsafe/sn_client#d867d8e8f20007e352f82bdd1c33a2bd6e7699b7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "sn_data_types"
-version = "0.11.33"
+version = "0.11.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b794b17824654e79cc411c37b1490e236b2a2a4bb24a6dbed645df915b6c47"
+checksum = "a8373c919a03460cdf229340fed185a10fa063c8ea0c72e19e0d7827e082482f"
 dependencies = [
  "bincode",
  "crdts",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.24.0"
+version = "0.25.4"
 dependencies = [
  "async-log",
  "base64 0.10.1",


### PR DESCRIPTION
Previously looked for `Version change` commit.
Also adds `--allow-dirty` to the cargo publish stage