### PR TITLE
Improved logging

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -10,6 +10,7 @@ on: pull_request
 
 jobs:
   merge:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   update_changelog:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-20.04
     # Dont run if we're on a release commit
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   lint:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_dependency_graphs.yml
+++ b/.github/workflows/generate_dependency_graphs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   generate-and-deploy:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     # only if we have a tag
     name: Release
     runs-on: ubuntu-20.04

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build_win_mac:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Build_win_mac
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,6 +63,7 @@ jobs:
           path: artifacts
 
   build_linux:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Build_Linux
     runs-on: ${{ matrix.os }}
     strategy:
@@ -105,6 +107,7 @@ jobs:
   # 'download-artifact' actions. We could perhaps implement our own 'retrieve all build artifacts'
   # action.
   deploy:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Deploy
     runs-on: ubuntu-latest
     needs: [build_win_mac, build_linux]
@@ -226,6 +229,7 @@ jobs:
 
   # Publish if we're on a release commit
   publish:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Publish
     runs-on: ubuntu-latest
     needs: [deploy]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   clippy:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Rustfmt-Clippy
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +50,7 @@ jobs:
         run: cargo clippy --all-targets
 
   coverage:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Code coverage check
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +92,7 @@ jobs:
           parallel-finished: true
 
   test:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -132,6 +135,7 @@ jobs:
 
   # list any unused dependencies using cargo-udeps
   cargo-udeps:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Unused dependency check
     runs-on: ubuntu-latest
     steps:
@@ -151,6 +155,7 @@ jobs:
   
   # list all duplicate dependencies. Note that this does not error if duplicates found
   duplicate-dependencies:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: List Duplicate Dependencies
     runs-on: ubuntu-latest
     steps:
@@ -169,6 +174,7 @@ jobs:
 
   # Test publish using --dry-run.
   test-publish:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Test Publish
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   audit:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -12,26 +12,27 @@ env:
 
 jobs:
   tag:
-      runs-on: ubuntu-latest
-      # Only run on a release commit
-      if: "startsWith(github.event.head_commit.message, 'chore(release):')"
-      steps:
-        - uses: actions/checkout@v2
-          with:
-            fetch-depth: '0'
-            token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
-        - run: echo "RELEASE_VERSION=$(git log -1 --pretty=%s)" >> $GITHUB_ENV
-        # parse out non-tag text
-        - run: echo "RELEASE_VERSION=$( echo $RELEASE_VERSION | sed 's/chore(release)://' )" >> $GITHUB_ENV
-        # remove spaces, but add back in `v` to tag, which is needed for standard-version
-        - run: echo "RELEASE_VERSION=v$(echo $RELEASE_VERSION | tr -d '[:space:]')" >> $GITHUB_ENV
-        - run: echo $RELEASE_VERSION
-        - run: git tag $RELEASE_VERSION
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    runs-on: ubuntu-latest
+    # Only run on a release commit
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+      - run: echo "RELEASE_VERSION=$(git log -1 --pretty=%s)" >> $GITHUB_ENV
+      # parse out non-tag text
+      - run: echo "RELEASE_VERSION=$( echo $RELEASE_VERSION | sed 's/chore(release)://' )" >> $GITHUB_ENV
+      # remove spaces, but add back in `v` to tag, which is needed for standard-version
+      - run: echo "RELEASE_VERSION=v$(echo $RELEASE_VERSION | tr -d '[:space:]')" >> $GITHUB_ENV
+      - run: echo $RELEASE_VERSION
+      - run: git tag $RELEASE_VERSION
 
-        - name: Setup git for push
-          run: |
-            git remote add github "$REPO"
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-        - name: Push tags to master
-          run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags
+      - name: Setup git for push
+        run: |
+          git remote add github "$REPO"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - name: Push tags to master
+        run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "async-log",
  "base64 0.10.1",

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -150,15 +150,15 @@ impl<T: Chunk> ChunkStore<T> {
         self.do_delete(&self.file_path(id)?).await
     }
 
-    /// Remaining space to max space ratio.
-    pub async fn remaining_space_ratio(&self) -> f64 {
+    /// Used space to max space ratio.
+    pub async fn used_space_ratio(&self) -> f64 {
         let used = self.total_used_space().await;
         let total = self.used_space.max_capacity().await;
-        let remaining_space_ratio = used as f64 / total as f64;
+        let used_space_ratio = used as f64 / total as f64;
         info!("Used space: {:?}", used);
         info!("Total space: {:?}", total);
-        info!("Remaining space ratio: {:?}", remaining_space_ratio);
-        remaining_space_ratio
+        info!("Used space ratio: {:?}", used_space_ratio);
+        used_space_ratio
     }
 
     /// Returns a data chunk previously stored under `id`.

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -192,8 +192,8 @@ impl ChunkStorage {
         Ok(NodeMessagingDuty::NoOp)
     }
 
-    pub async fn remaining_space_ratio(&self) -> f64 {
-        self.chunks.remaining_space_ratio().await
+    pub async fn used_space_ratio(&self) -> f64 {
+        self.chunks.used_space_ratio().await
     }
 
     // pub(crate) fn get_for_duplciation(

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -63,8 +63,8 @@ impl Chunks {
     }
 
     pub async fn check_storage(&self) -> Result<NodeOperation> {
-        info!("Checking remaining storage");
-        if self.chunk_storage.remaining_space_ratio().await > MAX_STORAGE_USAGE_RATIO {
+        info!("Checking used storage");
+        if self.chunk_storage.used_space_ratio().await > MAX_STORAGE_USAGE_RATIO {
             Ok(NodeDuty::StorageFull.into())
         } else {
             Ok(NodeOperation::NoOp)


### PR DESCRIPTION
Improved logging a bit:
- Display number of elders and adults also when a node has left (not just when a node has joined)
- Adapted length of surrounding lines to length of content. The result is like this:
```plain
[sn_node] INFO 2020-12-27T19:29:50.992580556+01:00 [src/node/node_duties/network_events.rs:46] -----------------------------------
[sn_node] INFO 2020-12-27T19:29:50.992648755+01:00 [src/node/node_duties/network_events.rs:47] | No. of Elders in our Section: 5 |
[sn_node] INFO 2020-12-27T19:29:50.992662555+01:00 [src/node/node_duties/network_events.rs:48] | No. of Adults in our Section: 4 |
[sn_node] INFO 2020-12-27T19:29:50.992678455+01:00 [src/node/node_duties/network_events.rs:49] -----------------------------------
```
(separators length depends on the max length of inner messages)

The only thing that is missing is to get this information as an adult. That would be great if Maidsafe allowed this. Not all users will be an elder, they might be disappointed to not have this information.

Other improvements (not related to logging):
- Renamed all "remaining space ratio" functions and messages to "used space ratio" which is the value that is really computed and displayed.
- Added a line in all Github Action jobs to execute them only when they are invoked from Maidsafe repository.  The aim is to avoid spurious errors and mails sent to people forking the repo. This is the same proposal as for qp2p [#189](https://github.com/maidsafe/qp2p/pull/189). By the way I received no news for this one.
- Corrected indentation in tag release workflow.
- Set version number in Cargo.lock in phase with Cargo.toml