### PR TITLE
chore(ci): add cargo deny check to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -181,6 +181,18 @@ jobs:
       - shell: bash
         run: ./scripts/duplicate_dependency_check
 
+  cargo-deny:
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # wget the shared deny.toml file from the QA repo
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   # Test publish using --dry-run.
   test-publish:
     if: github.repository_owner == 'maidsafe'


### PR DESCRIPTION
This fetches a shared deny.toml from the QA repo before running the cargo deny GH Action.

Created as draft as this new check will fail until the following 2 items are addressed:
1. Unwrap is removed from sn_client.
2. [RUSTSEC-2020-0043](https://github.com/maidsafe/sn_node/issues/1121) is addressed (bumped that issue).