### PR TITLE
Revert chaos caused by generating `chaos` builds

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_win_mac:
     if: github.repository_owner == 'maidsafe'
-    name: Build Release - win & mac
+    name: Build_win_mac
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -62,53 +62,9 @@ jobs:
           name: sn_node-${{ matrix.target }}-prod
           path: artifacts
 
-  build_chaos_win_mac:
-    if: github.repository_owner == 'maidsafe'
-    name: Build Chaos - win &mac
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, macOS-latest]
-        include:
-          - os: windows-latest
-            build-script: make build-chaos
-            target: x86_64-pc-windows-msvc
-          - os: macOS-latest
-            build-script: make build-chaos
-            target: x86_64-apple-darwin
-    steps:
-      - uses: actions/checkout@v2
-
-      # Install Rust
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      # Cache.
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      # Run build.
-      - shell: bash
-        run: ${{ matrix.build-script }}
-
-      # Upload artifacts.
-      - uses: actions/upload-artifact@master
-        with:
-          name: sn_node-${{ matrix.target }}-chaos
-          path: artifacts
-  
   build_linux:
     if: github.repository_owner == 'maidsafe'
-    name: Build Release - Linux
+    name: Build_Linux
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -147,47 +103,6 @@ jobs:
           name: sn_node-${{ matrix.target }}-prod
           path: artifacts
 
-  build_chaos_linux:
-    if: github.repository_owner == 'maidsafe'
-    name: Build Chaos - Linux
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        include:
-          - os: ubuntu-latest
-            build-script: make musl-chaos
-            target: x86_64-unknown-linux-musl
-    steps:
-      - uses: actions/checkout@v2
-
-      # Install Rust
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      # Cache.
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      # Run build.
-      - shell: bash
-        run: ${{ matrix.build-script }}
-
-      # Upload artifacts.
-      - uses: actions/upload-artifact@master
-        with:
-          name: sn_node-${{ matrix.target }}-chaos
-          path: artifacts
-
   # Deploy to GH Release and S3 if we're on a `chore(release):` commit
   deploy:
     if: |
@@ -216,21 +131,6 @@ jobs:
         with:
           name: sn_node-x86_64-apple-darwin-prod
           path: artifacts/prod/x86_64-apple-darwin/release
-      
-      # Also checkout the chaos artifacts built in the previous jobs.
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@master
-        with:
-          name: sn_node-x86_64-pc-windows-msvc-chaos
-          path: artifacts/chaos/x86_64-pc-windows-msvc/release
-      - uses: actions/download-artifact@master
-        with:
-          name: sn_node-x86_64-unknown-linux-musl-chaos
-          path: artifacts/chaos/x86_64-unknown-linux-musl/release
-      - uses: actions/download-artifact@master
-        with:
-          name: sn_node-x86_64-apple-darwin-chaos
-          path: artifacts/chaos/x86_64-apple-darwin/release
 
       # Get information for the release.
       - shell: bash
@@ -247,9 +147,7 @@ jobs:
       # Create `deploy` directory and put the artifacts into tar/zip archives for deployment with the release.
       - name: chmod
         shell: bash
-        run: |
-          chmod -R +x artifacts/prod
-          chmod -R +x artifacts/chaos
+        run: chmod -R +x artifacts/prod
       - shell: bash
         run: make package-version-artifacts-for-deploy
 
@@ -263,13 +161,11 @@ jobs:
           description="${description//$'\r'/'%0D'}"
           echo "::set-output name=description::$description"
 
-      # Upload all the release archives, including chaos, to S3
+      # Upload all the release archives to S3
       - name: Upload archives to S3
-        run: |
-          aws s3 sync deploy/prod s3://sn-node --acl public-read
-          aws s3 sync deploy/chaos s3://sn-node --acl public-read
+        run: aws s3 sync deploy/prod s3://sn-node --acl public-read
 
-      # Create the GitHub release and attach sn_node archives as assets.
+      # Create the release and attach sn_node archives as assets.
       - uses: csexton/create-release@add-body
         id: create_release
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -195,7 +195,7 @@ jobs:
       startsWith(github.event.head_commit.message, 'chore(release):')
     name: Deploy
     runs-on: ubuntu-latest
-    needs: [build_win_mac, build_linux, build_chaos_win_mac, build_chaos_linux]
+    needs: [build_win_mac, build_linux]
     env:
       AWS_ACCESS_KEY_ID: AKIAVVODCRMSJ5MV63VB
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
@@ -216,10 +216,6 @@ jobs:
         with:
           name: sn_node-x86_64-apple-darwin-prod
           path: artifacts/prod/x86_64-apple-darwin/release
-
-      - name: chmod prod artifacts
-        shell: bash
-        run: chmod -R +x artifacts/prod
       
       # Also checkout the chaos artifacts built in the previous jobs.
       - uses: actions/checkout@v2
@@ -236,10 +232,6 @@ jobs:
           name: sn_node-x86_64-apple-darwin-chaos
           path: artifacts/chaos/x86_64-apple-darwin/release
 
-      - name: chmod chaos artifacts
-        shell: bash
-        run: chmod -R +x artifacts/chaos
-
       # Get information for the release.
       - shell: bash
         id: commit_message
@@ -252,13 +244,14 @@ jobs:
           version=$(grep "^version" < Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
           echo "::set-output name=version::$version"
 
-      # Create `deploy` directory and put the prod artifacts into tar/zip archives for deployment with the release.
+      # Create `deploy` directory and put the artifacts into tar/zip archives for deployment with the release.
+      - name: chmod
+        shell: bash
+        run: |
+          chmod -R +x artifacts/prod
+          chmod -R +x artifacts/chaos
       - shell: bash
-        run: make package-prod-version-artifacts-for-deploy
-
-      # Now add the chaos artifacts into tar/zip archives for deployment with the release.
-      - shell: bash
-        run: make package-chaos-version-artifacts-for-deploy
+        run: make package-version-artifacts-for-deploy
 
       # Get release description (requires generated archives)
       - shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.25.32"
+version = "0.25.31"
 dependencies = [
  "async-log",
  "base64 0.10.1",

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,59 @@
+FROM rust:latest
+
+ARG OPENSSL_VERSION=1.0.2r
+
+RUN addgroup --gid 1001 maidsafe && \
+    adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
+    # The parent container sets this to the 'staff' group, which causes problems
+    # with reading code stored in Cargo's registry.
+    chgrp -R maidsafe /usr/local
+
+# Install fixuid for dealing with permissions issues with mounted volumes.
+# We could perhaps put this into a base container at a later stage.
+RUN USER=maidsafe && \
+    GROUP=maidsafe && \
+    echo "06b3e053be5aaccc91dd5a45faf2356f  fixuid-0.4-linux-amd64.tar.gz" > fixuid-0.4-linux-amd64.tar.gz.md5 && \
+    curl -OSsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz && \
+    md5sum -c fixuid-0.4-linux-amd64.tar.gz.md5 && \
+    tar -C /usr/local/bin -xzf fixuid-0.4-linux-amd64.tar.gz && \
+    rm fixuid-0.4-linux-amd64.tar.gz && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+RUN apt-get update -y && \
+    apt-get install -y \
+        gcc \
+        musl-dev \
+        musl-tools && \
+    mkdir -p /usr/local/musl/include && \
+    ln -s /usr/include/linux /usr/local/musl/include/linux && \
+    ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm && \
+    ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic && \
+    curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
+    tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && \
+    cd openssl-$OPENSSL_VERSION && \
+    CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
+    CC=musl-gcc C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
+    CC=musl-gcc C_INCLUDE_PATH=/usr/local/musl/include/ make && \
+    CC=musl-gcc C_INCLUDE_PATH=/usr/local/musl/include/ make install && \
+    mkdir /target && \
+    chown maidsafe:maidsafe /target && \
+    mkdir /usr/src/sn_node && \
+    chown maidsafe:maidsafe /usr/src/sn_node && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/sn_node
+COPY . .
+
+# During the build process, ownership of the source directory needs changed in advance because
+# the tests write a file and you need permissions for that.
+RUN chown -R maidsafe:maidsafe /usr/src/sn_node
+USER maidsafe:maidsafe
+ENV CARGO_TARGET_DIR=/target \
+    RUST_BACKTRACE=1
+RUN rustup component add rustfmt clippy && \
+    rustup target add x86_64-unknown-linux-musl
+ENTRYPOINT ["fixuid"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ SN_NODE_VERSION := $(shell grep "^version" < Cargo.toml | head -n 1 | awk '{ pri
 UNAME_S := $(shell uname -s)
 DEPLOY_PATH := deploy
 DEPLOY_PROD_PATH := ${DEPLOY_PATH}/prod
-DEPLOY_CHAOS_PATH := ${DEPLOY_PATH}/chaos
 
 build:
 ifeq ($(UNAME_S),Linux)
@@ -29,36 +28,11 @@ endif
 	find target/x86_64-unknown-linux-musl/release \
 		-maxdepth 1 -type f -exec cp '{}' artifacts \;
 
-build-chaos:
-ifeq ($(UNAME_S),Linux)
-	@echo "This target should not be used for Linux - please use the `musl-chaos` target."
-	@exit 1
-endif
-	rm -rf artifacts
-	mkdir artifacts
-	cargo build --release --features=chaos,simulated-payouts
-	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
-
-musl-chaos:
-ifneq ($(UNAME_S),Linux)
-	@echo "This target only applies to Linux - please use the `build-chaos` target."
-	@exit 1
-endif
-	rm -rf target
-	rm -rf artifacts
-	mkdir artifacts
-	sudo apt update -y && sudo apt install -y musl-tools
-	rustup target add x86_64-unknown-linux-musl
-	cargo build --release --features=chaos,simulated-payouts --target x86_64-unknown-linux-musl --verbose
-	find target/x86_64-unknown-linux-musl/release \
-		-maxdepth 1 -type f -exec cp '{}' artifacts \;
-
 .ONESHELL:
 package-version-artifacts-for-deploy:
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
 	mkdir -p ${DEPLOY_PROD_PATH}
-	mkdir -p ${DEPLOY_CHAOS_PATH}
 
 	zip -j sn_node-${SN_NODE_VERSION}-x86_64-unknown-linux-musl.zip \
 		artifacts/prod/x86_64-unknown-linux-musl/release/sn_node
@@ -86,20 +60,5 @@ package-version-artifacts-for-deploy:
 	tar -C artifacts/prod/x86_64-apple-darwin/release \
 		-zcvf sn_node-latest-x86_64-apple-darwin.tar.gz sn_node
 
-	tar -C artifacts/chaos/x86_64-unknown-linux-musl/release \
-		-zcvf sn_node-CHAOS-${SN_NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz sn_node
-	tar -C artifacts/chaos/x86_64-unknown-linux-musl/release \
-		-zcvf sn_node-CHAOS-latest-x86_64-unknown-linux-musl.tar.gz sn_node
-	tar -C artifacts/chaos/x86_64-pc-windows-msvc/release \
-		-zcvf sn_node-CHAOS-${SN_NODE_VERSION}-x86_64-pc-windows-msvc.tar.gz sn_node.exe
-	tar -C artifacts/chaos/x86_64-pc-windows-msvc/release \
-		-zcvf sn_node-CHAOS-latest-x86_64-pc-windows-msvc.tar.gz sn_node.exe
-	tar -C artifacts/chaos/x86_64-apple-darwin/release \
-		-zcvf sn_node-CHAOS-${SN_NODE_VERSION}-x86_64-apple-darwin.tar.gz sn_node
-	tar -C artifacts/chaos/x86_64-apple-darwin/release \
-		-zcvf sn_node-CHAOS-latest-x86_64-apple-darwin.tar.gz sn_node
-
 	mv *.zip ${DEPLOY_PROD_PATH}
-	mv sn_node-${SN_NODE_VERSION}-*.tar.gz ${DEPLOY_PROD_PATH}
-	mv sn_node-latest-*.tar.gz ${DEPLOY_PROD_PATH}
-	mv sn_node-CHAOS-*.tar.gz ${DEPLOY_CHAOS_PATH}
+	mv *.tar.gz ${DEPLOY_PROD_PATH}

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,11 @@ endif
 		-maxdepth 1 -type f -exec cp '{}' artifacts \;
 
 .ONESHELL:
-package-prod-version-artifacts-for-deploy:
+package-version-artifacts-for-deploy:
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
 	mkdir -p ${DEPLOY_PROD_PATH}
+	mkdir -p ${DEPLOY_CHAOS_PATH}
 
 	zip -j sn_node-${SN_NODE_VERSION}-x86_64-unknown-linux-musl.zip \
 		artifacts/prod/x86_64-unknown-linux-musl/release/sn_node
@@ -85,15 +86,6 @@ package-prod-version-artifacts-for-deploy:
 	tar -C artifacts/prod/x86_64-apple-darwin/release \
 		-zcvf sn_node-latest-x86_64-apple-darwin.tar.gz sn_node
 
-	mv *.zip ${DEPLOY_PROD_PATH}
-	mv sn_node-${SN_NODE_VERSION}-*.tar.gz ${DEPLOY_PROD_PATH}
-	mv sn_node-latest-*.tar.gz ${DEPLOY_PROD_PATH}
-
-.ONESHELL:
-package-chaos-version-artifacts-for-deploy:
-	rm -rf ${DEPLOY_CHAOS_PATH}
-	mkdir -p ${DEPLOY_CHAOS_PATH}
-
 	tar -C artifacts/chaos/x86_64-unknown-linux-musl/release \
 		-zcvf sn_node-CHAOS-${SN_NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz sn_node
 	tar -C artifacts/chaos/x86_64-unknown-linux-musl/release \
@@ -107,4 +99,7 @@ package-chaos-version-artifacts-for-deploy:
 	tar -C artifacts/chaos/x86_64-apple-darwin/release \
 		-zcvf sn_node-CHAOS-latest-x86_64-apple-darwin.tar.gz sn_node
 
+	mv *.zip ${DEPLOY_PROD_PATH}
+	mv sn_node-${SN_NODE_VERSION}-*.tar.gz ${DEPLOY_PROD_PATH}
+	mv sn_node-latest-*.tar.gz ${DEPLOY_PROD_PATH}
 	mv sn_node-CHAOS-*.tar.gz ${DEPLOY_CHAOS_PATH}


### PR DESCRIPTION
Seemed like a simple enough addition to make but turns out it results in zips not uploading to S3 and the tar files being empty - reverting to unblock others & I can look at this on a fork.