### PR TITLE
chore(cache): do not generate cache for macOS build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_win_mac:
     if: github.repository_owner == 'maidsafe'
-    name: Build_win_mac
+    name: Build Windows & macOS
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -44,6 +44,7 @@ jobs:
 
       # Cache.
       - name: Cargo cache registry, index and build
+        if: matrix.os != 'macOS-latest'
         uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
seems to be causing an error on build - `error[E0463]: can't find crate for `serde_derive` which `pickledb` depends on`