### PR TITLE
refactor(nodeinfo): remove init_mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "async-log",
  "async-trait",

--- a/src/capacity/chunk_dbs.rs
+++ b/src/capacity/chunk_dbs.rs
@@ -24,10 +24,10 @@ pub struct ChunkHolderDbs {
 
 impl ChunkHolderDbs {
     ///
-    pub fn new(path: &Path, init: utils::Init) -> Result<Self> {
-        let metadata = utils::new_auto_dump_db(path, BLOB_META_DB_NAME, init)?;
-        let holders = utils::new_auto_dump_db(path, HOLDER_META_DB_NAME, init)?;
-        let full_adults = utils::new_auto_dump_db(path, FULL_ADULTS_DB_NAME, init)?;
+    pub fn new(path: &Path) -> Result<Self> {
+        let metadata = utils::new_auto_dump_db(path, BLOB_META_DB_NAME)?;
+        let holders = utils::new_auto_dump_db(path, HOLDER_META_DB_NAME)?;
+        let full_adults = utils::new_auto_dump_db(path, FULL_ADULTS_DB_NAME)?;
         let metadata = Rc::new(RefCell::new(metadata));
         let holders = Rc::new(RefCell::new(holders));
         let full_adults = Rc::new(RefCell::new(full_adults));

--- a/src/chunk_store/tests.rs
+++ b/src/chunk_store/tests.rs
@@ -10,7 +10,7 @@ use super::{
     chunk::{Chunk, ChunkId},
     ChunkStore, Result as ChunkStoreResult, Subdir, UsedSpace,
 };
-use crate::{utils::Init, Error, Result, ToDbKey};
+use crate::{Error, Result, ToDbKey};
 use rand::{distributions::Standard, rngs::ThreadRng, Rng};
 use serde::{Deserialize, Serialize};
 use std::{path::Path, u64};
@@ -87,8 +87,7 @@ async fn successful_put() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store =
-        ChunkStore::<Data>::new(root.path(), used_space.clone(), Init::New).await?;
+    let mut chunk_store = ChunkStore::<Data>::new(root.path(), used_space.clone()).await?;
 
     for (index, (data, size)) in chunks.data_and_sizes.iter().enumerate().rev() {
         let the_data = &Data {
@@ -124,7 +123,7 @@ async fn failed_put_when_not_enough_space() -> Result<()> {
     let root = temp_dir()?;
     let capacity = 32;
     let used_space = UsedSpace::new(capacity);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
 
     let data = Data {
         id: Id(rng.gen()),
@@ -149,7 +148,7 @@ async fn delete() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
 
     for (index, (data, size)) in chunks.data_and_sizes.iter().enumerate() {
         let the_data = &Data {
@@ -174,7 +173,7 @@ async fn put_and_get_value_should_be_same() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
 
     for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
         chunk_store
@@ -200,7 +199,7 @@ async fn overwrite_value() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
 
     for (data, size) in chunks.data_and_sizes {
         chunk_store
@@ -221,8 +220,7 @@ async fn overwrite_value() -> Result<()> {
 async fn get_fails_when_key_does_not_exist() -> Result<()> {
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let chunk_store: ChunkStore<Data> =
-        ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
+    let chunk_store: ChunkStore<Data> = ChunkStore::new(root.path(), used_space.clone()).await?;
 
     let id = Id(new_rng().gen());
     match chunk_store.get(&id) {
@@ -240,7 +238,7 @@ async fn keys() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone(), Init::New).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
 
     for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
         let id = Id(index as u64);

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -21,7 +21,7 @@
 // What things do we _need_ to access most current state of?
 // - ..
 
-use crate::{utils, Network, Result};
+use crate::{Network, Result};
 use bls::{PublicKeySet, PublicKeyShare};
 use ed25519_dalek::PublicKey as Ed25519PublicKey;
 use itertools::Itertools;
@@ -354,9 +354,7 @@ impl NodeInteraction {
     }
 }
 
-/// Info about the node used
-/// to init its various dbs
-/// (among things).
+/// Info about the node.
 #[derive(Clone)]
 pub struct NodeInfo {
     ///
@@ -365,8 +363,6 @@ pub struct NodeInfo {
     pub node_id: PublicKey,
     ///
     pub root_dir: PathBuf,
-    ///
-    pub init_mode: utils::Init,
     /// Upper limit in bytes for allowed network storage on this node.
     /// An Adult would be using the space for chunks,
     /// while an Elder uses it for metadata.

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -36,13 +36,9 @@ impl ChunkStorage {
     pub(crate) async fn new(adult_state: AdultState) -> Result<Self> {
         let node_info = adult_state.info();
         let used_space = UsedSpace::new(node_info.max_storage_capacity);
-        let chunks = BlobChunkStore::new(node_info.path(), used_space, node_info.init_mode).await?;
+        let chunks = BlobChunkStore::new(node_info.path(), used_space).await?;
         let wrapping = AdultMsgWrapping::new(adult_state, AdultDuties::ChunkStorage);
         Ok(Self { chunks, wrapping })
-    }
-
-    pub fn update_msg_wrapping(&mut self, adult_state: AdultState) {
-        self.wrapping = AdultMsgWrapping::new(adult_state, AdultDuties::ChunkStorage);
     }
 
     pub(crate) async fn store(

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -40,10 +40,6 @@ impl Chunks {
         })
     }
 
-    pub fn update_msg_wrapping(&mut self, adult_state: AdultState) {
-        self.chunk_storage.update_msg_wrapping(adult_state)
-    }
-
     pub async fn receive_msg(&mut self, msg: MsgEnvelope) -> Result<NodeMessagingDuty> {
         trace!(
             "{}: Received ({:?} from src {:?}",

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -31,10 +31,6 @@ impl AdultDuties {
         Ok(Self { state, chunks })
     }
 
-    pub fn update_msg_wrapping(&mut self, adult_state: AdultState) {
-        self.chunks.update_msg_wrapping(adult_state)
-    }
-
     ///
     pub fn state(&self) -> &AdultState {
         &self.state

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -32,7 +32,7 @@ pub(super) struct MapStorage {
 impl MapStorage {
     pub(super) async fn new(node_info: &NodeInfo, wrapping: ElderMsgWrapping) -> Result<Self> {
         let used_space = UsedSpace::new(node_info.max_storage_capacity);
-        let chunks = MapChunkStore::new(node_info.path(), used_space, node_info.init_mode).await?;
+        let chunks = MapChunkStore::new(node_info.path(), used_space).await?;
         Ok(Self { chunks, wrapping })
     }
 

--- a/src/node/elder_duties/data_section/metadata/sequence_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/sequence_storage.rs
@@ -35,8 +35,7 @@ pub(super) struct SequenceStorage {
 impl SequenceStorage {
     pub(super) async fn new(node_info: &NodeInfo, wrapping: ElderMsgWrapping) -> Result<Self> {
         let used_space = UsedSpace::new(node_info.max_storage_capacity);
-        let chunks =
-            SequenceChunkStore::new(node_info.path(), used_space, node_info.init_mode).await?;
+        let chunks = SequenceChunkStore::new(node_info.path(), used_space).await?;
         Ok(Self { chunks, wrapping })
     }
 

--- a/src/node/elder_duties/key_section/transfers/store.rs
+++ b/src/node/elder_duties/key_section/transfers/store.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{utils, utils::Init, Error, Result, ToDbKey};
+use crate::{utils, Error, Result, ToDbKey};
 use log::{debug, trace};
 use pickledb::PickleDb;
 use serde::{de::DeserializeOwned, Serialize};
@@ -31,13 +31,12 @@ impl<'a, TEvent: Debug + Serialize + DeserializeOwned> TransferStore<TEvent>
 where
     TEvent: 'a,
 {
-    pub fn new(id: XorName, root_dir: &PathBuf, init_mode: Init) -> Result<Self> {
+    pub fn new(id: XorName, root_dir: &PathBuf) -> Result<Self> {
         let db_dir = root_dir.join(Path::new(TRANSFERS_DIR_NAME));
         let db_name = format!("{}{}", id.to_db_key()?, DB_EXTENSION);
         Ok(Self {
             id,
-            db: utils::new_auto_dump_db(db_dir.as_path(), db_name, init_mode)?,
-            //db: utils::new_periodic_dump_db(db_dir.as_path(), db_name, init_mode)?,
+            db: utils::new_auto_dump_db(db_dir.as_path(), db_name)?,
             _phantom: PhantomData::default(),
         })
     }
@@ -107,7 +106,7 @@ mod test {
         let id = xor_name::XorName::random();
         let tmp_dir = TempDir::new("root")?;
         let root_dir = tmp_dir.into_path();
-        let mut store = TransferStore::new(id, &root_dir, Init::New)?;
+        let mut store = TransferStore::new(id, &root_dir)?;
         let wallet_id = get_random_pk();
         let mut rng = rand::thread_rng();
         let bls_secret_key = SecretKeySet::random(0, &mut rng);

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -31,7 +31,7 @@ pub struct ElderDuties {
 impl ElderDuties {
     pub async fn new(wallet_info: WalletInfo, state: ElderState) -> Result<Self> {
         let info = state.info();
-        let dbs = ChunkHolderDbs::new(info.path(), info.init_mode)?;
+        let dbs = ChunkHolderDbs::new(info.path())?;
         let rate_limit = RateLimit::new(state.clone(), Capacity::new(dbs.clone()));
         let key_section = KeySection::new(rate_limit, state.clone()).await?;
         let data_section = DataSection::new(info, dbs, wallet_info, state.clone()).await?;
@@ -135,7 +135,7 @@ impl ElderDuties {
     pub async fn finish_elder_change(&mut self, state: ElderState) -> Result<()> {
         // 2. Then we must update key section..
         let info = state.info();
-        let dbs = ChunkHolderDbs::new(info.path(), crate::utils::Init::Load)?;
+        let dbs = ChunkHolderDbs::new(info.path())?;
         let rate_limit = RateLimit::new(state.clone(), Capacity::new(dbs));
         self.key_section.elders_changed(state, rate_limit);
         Ok(())

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -19,7 +19,6 @@ use crate::{
         node_ops::{GatewayDuty, NetworkDuty, NodeDuty, NodeOperation},
         state_db::{get_age_group, store_age_group, store_new_reward_keypair, AgeGroup},
     },
-    utils::Init,
     Config, Error, Network, NodeInfo, Result,
 };
 use bls::SecretKey;
@@ -79,7 +78,6 @@ impl Node {
             genesis: config.is_first(),
             node_id: PublicKey::Ed25519(network_api.public_key().await),
             root_dir: root_dir_buf,
-            init_mode: Init::New,
             /// Upper limit in bytes for allowed network storage on this node.
             /// An Adult would be using the space for chunks,
             /// while an Elder uses it for metadata.

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -558,7 +558,7 @@ impl NodeDuties {
                 }
                 Ok(NodeOperation::NoOp)
             }
-            _ => return Err(Error::InvalidOperation),
+            _ => Err(Error::InvalidOperation),
         }
     }
 
@@ -653,10 +653,11 @@ impl NodeDuties {
             Stage::AwaitingGenesisThreshold(_) => Ok(NodeOperation::NoOp),
             Stage::ProposingGenesis(_) => Ok(NodeOperation::NoOp), // TODO: Queue up (or something?)!!
             Stage::AccumulatingGenesis(_) => Ok(NodeOperation::NoOp), // TODO: Queue up (or something?)!!
-            Stage::Adult(old_state) => {
+            Stage::Adult(_old_state) => {
                 let state =
                     AdultState::new(self.node_info.clone(), self.network_api.clone()).await?;
-                old_state.update_msg_wrapping(state);
+                let duties = AdultDuties::new(state).await?;
+                self.stage = Stage::Adult(duties);
                 Ok(NodeOperation::NoOp)
             }
             Stage::Elder(elder) => elder.initiate_elder_change(prefix, new_section_key).await,


### PR DESCRIPTION
- Init mode is not needed, as we simply try load from the databases, or else create new.
- Fixes bugs resulting from the continued use of `init_mode`, such as the update of `AdultDuties` on `EldersChanged` event, which resulted in overwriting dbs due to incorrectly relying on `init_mode`, which is not static in the same way as the rest of the `NodeInfo`.