### PR TITLE
Reduce Redundant Storage of NodeInfo & fix Incorrect Tracking on Global Used Space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,11 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
+<<<<<<< HEAD
 version = "0.26.8"
+=======
+version = "0.26.9"
+>>>>>>> a39b0043 (fix: unifies used space across node)
 dependencies = [
  "async-log",
  "async-trait",
@@ -2432,7 +2436,6 @@ dependencies = [
  "tempdir",
  "thiserror",
  "threshold_crypto",
- "tiny-keccak 1.5.0",
  "tokio",
  "xor_name",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a559ce34615abd3145e6ca99df0e33ac069dc5298d1bfecfcc1ca821803f0cb2"
+checksum = "7ce7a913007f8d825242cd5017962f09bc3f19f91a382498c1e6756c842e3908"
 
 [[package]]
 name = "maplit"
@@ -2267,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd2af560da3c1fdc02cb80965289254fc35dff869810061e2d8290ee48848ae"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -2393,11 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-<<<<<<< HEAD
-version = "0.26.8"
-=======
-version = "0.26.9"
->>>>>>> a39b0043 (fix: unifies used space across node)
+version = "0.26.11"
 dependencies = [
  "async-log",
  "async-trait",
@@ -2471,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "sn_transfers"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351262d2a0339a5265b6351b113fbc6174cbada8901a9d79d75d7f5679f87997"
+checksum = "c94e8edc973121e93076707bcf2ce3ab88cecac801505813769086e5415f2807"
 dependencies = [
  "bincode",
  "crdts",

--- a/src/chunk_store/used_space.rs
+++ b/src/chunk_store/used_space.rs
@@ -43,6 +43,12 @@ impl UsedSpace {
         }
     }
 
+    /// Clears the entire storage and sets total_value back to zero
+    /// while removing all local stores
+    pub async fn reset(&self) {
+        inner::UsedSpace::reset(self.inner.clone()).await
+    }
+
     /// Returns the maximum capacity (e.g. the maximum
     /// value that total() can return)
     pub async fn max_capacity(&self) -> u64 {
@@ -126,6 +132,15 @@ mod inner {
                 local_stores: HashMap::new(),
                 next_id: 0u64,
             }
+        }
+
+        /// Clears the storage, setting total value ot zero
+        /// and dropping local stores, but leaves
+        /// the capacity and next_id unchanged
+        pub async fn reset(used_space: Arc<Mutex<UsedSpace>>) {
+            let mut used_space_lock = used_space.lock().await;
+            used_space_lock.total_value = 0;
+            used_space_lock.local_stores.clear();
         }
 
         /// Returns the maximum capacity (e.g. the maximum

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -21,8 +21,7 @@
 // What things do we _need_ to access most current state of?
 // - ..
 
-use crate::chunk_store::UsedSpace;
-use crate::{Network, Result};
+use crate::{chunk_store::UsedSpace, Network, Result};
 use bls::{PublicKeySet, PublicKeyShare};
 use ed25519_dalek::PublicKey as Ed25519PublicKey;
 use itertools::Itertools;

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -59,7 +59,6 @@ impl NodeState {
 #[derive(Clone)]
 ///
 pub struct AdultState {
-    info: NodeInfo,
     prefix: Prefix,
     node_name: XorName,
     node_id: Ed25519PublicKey,
@@ -73,9 +72,8 @@ impl AdultState {
     /// Takes a snapshot of current state
     /// https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+is%3Aopen+eval_order_dependence
     #[allow(clippy::eval_order_dependence)]
-    pub async fn new(info: NodeInfo, network: Network) -> Result<Self> {
+    pub async fn new(network: Network) -> Result<Self> {
         Ok(Self {
-            info,
             prefix: network.our_prefix().await,
             node_name: network.our_name().await,
             node_id: network.public_key().await,
@@ -89,11 +87,6 @@ impl AdultState {
     // ---------------------------------------------------
     // ----------------- STATIC STATE --------------------
     // ---------------------------------------------------
-
-    /// Static state
-    pub fn info(&self) -> &NodeInfo {
-        &self.info
-    }
 
     /// Static state
     pub fn node_name(&self) -> XorName {

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -358,8 +358,6 @@ pub struct NodeInfo {
     ///
     pub genesis: bool,
     ///
-    pub node_id: PublicKey,
-    ///
     pub root_dir: PathBuf,
     /// Upper limit in bytes for allowed network storage on this node.
     /// An Adult would be using the space for chunks,

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -21,6 +21,7 @@
 // What things do we _need_ to access most current state of?
 // - ..
 
+use crate::chunk_store::UsedSpace;
 use crate::{Network, Result};
 use bls::{PublicKeySet, PublicKeyShare};
 use ed25519_dalek::PublicKey as Ed25519PublicKey;
@@ -359,10 +360,8 @@ pub struct NodeInfo {
     pub genesis: bool,
     ///
     pub root_dir: PathBuf,
-    /// Upper limit in bytes for allowed network storage on this node.
-    /// An Adult would be using the space for chunks,
-    /// while an Elder uses it for metadata.
-    pub max_storage_capacity: u64,
+    ///
+    pub used_space: UsedSpace,
     /// The key used by the node to receive earned rewards.
     pub reward_key: PublicKey,
 }

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -108,7 +108,6 @@ impl AdultState {
 #[derive(Clone)]
 ///
 pub struct ElderState {
-    info: NodeInfo,
     prefix: Prefix,
     node_name: XorName,
     node_id: Ed25519PublicKey,
@@ -125,9 +124,8 @@ impl ElderState {
     /// Takes a snapshot of current state
     /// https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+is%3Aopen+eval_order_dependence
     #[allow(clippy::eval_order_dependence)]
-    pub async fn new(info: &NodeInfo, network: Network) -> Result<Self> {
+    pub async fn new(network: Network) -> Result<Self> {
         Ok(Self {
-            info: info.clone(),
             prefix: network.our_prefix().await,
             node_name: network.our_name().await,
             node_id: network.public_key().await,
@@ -170,11 +168,6 @@ impl ElderState {
     // ---------------------------------------------------
     // ----------------- STATIC STATE --------------------
     // ---------------------------------------------------
-
-    /// Static state
-    pub fn info(&self) -> &NodeInfo {
-        &self.info
-    }
 
     /// Static state
     pub fn prefix(&self) -> &Prefix {

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -11,7 +11,7 @@ use crate::{
     chunk_store::BlobChunkStore,
     error::convert_to_error_message,
     node::{msg_wrapping::AdultMsgWrapping, node_ops::NodeMessagingDuty, Error},
-    AdultState, Result,
+    AdultState, NodeInfo, Result,
 };
 use log::{error, info};
 use sn_data_types::{Blob, BlobAddress, Signature};
@@ -33,9 +33,8 @@ pub(crate) struct ChunkStorage {
 }
 
 impl ChunkStorage {
-    pub(crate) async fn new(adult_state: AdultState) -> Result<Self> {
-        let node_info = adult_state.info();
-        let chunks = BlobChunkStore::new(node_info.path(), node_info.used_space.clone()).await?;
+    pub(crate) async fn new(node_info: &NodeInfo, adult_state: AdultState) -> Result<Self> {
+        let chunks = BlobChunkStore::new(&node_info.root_dir, node_info.used_space.clone()).await?;
         let wrapping = AdultMsgWrapping::new(adult_state, AdultDuties::ChunkStorage);
         Ok(Self { chunks, wrapping })
     }

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -8,7 +8,7 @@
 
 //pub use crate::chunk_store::UsedSpace;
 use crate::{
-    chunk_store::{BlobChunkStore, UsedSpace},
+    chunk_store::BlobChunkStore,
     error::convert_to_error_message,
     node::{msg_wrapping::AdultMsgWrapping, node_ops::NodeMessagingDuty, Error},
     AdultState, Result,
@@ -35,8 +35,7 @@ pub(crate) struct ChunkStorage {
 impl ChunkStorage {
     pub(crate) async fn new(adult_state: AdultState) -> Result<Self> {
         let node_info = adult_state.info();
-        let used_space = UsedSpace::new(node_info.max_storage_capacity);
-        let chunks = BlobChunkStore::new(node_info.path(), used_space).await?;
+        let chunks = BlobChunkStore::new(node_info.path(), node_info.used_space.clone()).await?;
         let wrapping = AdultMsgWrapping::new(adult_state, AdultDuties::ChunkStorage);
         Ok(Self { chunks, wrapping })
     }

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//pub use crate::chunk_store::UsedSpace;
 use crate::{
     chunk_store::BlobChunkStore,
     error::convert_to_error_message,

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -12,7 +12,7 @@ mod writing;
 
 use crate::{
     node::node_ops::{NodeDuty, NodeMessagingDuty, NodeOperation},
-    AdultState, Error, Result,
+    AdultState, Error, NodeInfo, Result,
 };
 use chunk_storage::ChunkStorage;
 use log::{info, trace};
@@ -34,9 +34,9 @@ pub(crate) struct Chunks {
 }
 
 impl Chunks {
-    pub async fn new(adult_state: AdultState) -> Result<Self> {
+    pub async fn new(node_info: &NodeInfo, adult_state: AdultState) -> Result<Self> {
         Ok(Self {
-            chunk_storage: ChunkStorage::new(adult_state).await?,
+            chunk_storage: ChunkStorage::new(&node_info, adult_state).await?,
         })
     }
 

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         AdultDuty, ChunkReplicationCmd, ChunkReplicationDuty, ChunkReplicationQuery,
         ChunkStoreDuty, IntoNodeOp, NodeOperation,
     },
-    AdultState, Result,
+    AdultState, NodeInfo, Result,
 };
 use std::fmt::{self, Display, Formatter};
 
@@ -26,8 +26,8 @@ pub struct AdultDuties {
 }
 
 impl AdultDuties {
-    pub async fn new(state: AdultState) -> Result<Self> {
-        let chunks = Chunks::new(state.clone()).await?;
+    pub async fn new(node_info: &NodeInfo, state: AdultState) -> Result<Self> {
+        let chunks = Chunks::new(node_info, state.clone()).await?;
         Ok(Self { state, chunks })
     }
 

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -7,12 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    chunk_store::MapChunkStore,
-    error::convert_to_error_message,
-    node::msg_wrapping::ElderMsgWrapping,
-    node::node_ops::NodeMessagingDuty,
-    node::NodeInfo,
-    Error, Result,
+    chunk_store::MapChunkStore, error::convert_to_error_message,
+    node::msg_wrapping::ElderMsgWrapping, node::node_ops::NodeMessagingDuty, node::NodeInfo, Error,
+    Result,
 };
 use log::info;
 use sn_data_types::{

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    chunk_store::{MapChunkStore, UsedSpace},
+    chunk_store::MapChunkStore,
     error::convert_to_error_message,
     node::msg_wrapping::ElderMsgWrapping,
     node::node_ops::NodeMessagingDuty,
@@ -33,8 +33,7 @@ pub(super) struct MapStorage {
 
 impl MapStorage {
     pub(super) async fn new(node_info: &NodeInfo, wrapping: ElderMsgWrapping) -> Result<Self> {
-        let used_space = UsedSpace::new(node_info.max_storage_capacity);
-        let chunks = MapChunkStore::new(node_info.path(), used_space).await?;
+        let chunks = MapChunkStore::new(node_info.path(), node_info.used_space.clone()).await?;
         Ok(Self { chunks, wrapping })
     }
 

--- a/src/node/elder_duties/data_section/metadata/sequence_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/sequence_storage.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    chunk_store::{SequenceChunkStore, UsedSpace},
+    chunk_store::SequenceChunkStore,
     error::convert_to_error_message,
     node::msg_wrapping::ElderMsgWrapping,
     node::node_ops::NodeMessagingDuty,
@@ -34,8 +34,7 @@ pub(super) struct SequenceStorage {
 
 impl SequenceStorage {
     pub(super) async fn new(node_info: &NodeInfo, wrapping: ElderMsgWrapping) -> Result<Self> {
-        let used_space = UsedSpace::new(node_info.max_storage_capacity);
-        let chunks = SequenceChunkStore::new(node_info.path(), used_space).await?;
+        let chunks = SequenceChunkStore::new(node_info.path(), node_info.used_space.clone()).await?;
         Ok(Self { chunks, wrapping })
     }
 

--- a/src/node/elder_duties/data_section/metadata/sequence_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/sequence_storage.rs
@@ -7,12 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    chunk_store::SequenceChunkStore,
-    error::convert_to_error_message,
-    node::msg_wrapping::ElderMsgWrapping,
-    node::node_ops::NodeMessagingDuty,
-    node::NodeInfo,
-    Error, Result,
+    chunk_store::SequenceChunkStore, error::convert_to_error_message,
+    node::msg_wrapping::ElderMsgWrapping, node::node_ops::NodeMessagingDuty, node::NodeInfo, Error,
+    Result,
 };
 use log::info;
 use sn_data_types::{
@@ -34,7 +31,8 @@ pub(super) struct SequenceStorage {
 
 impl SequenceStorage {
     pub(super) async fn new(node_info: &NodeInfo, wrapping: ElderMsgWrapping) -> Result<Self> {
-        let chunks = SequenceChunkStore::new(node_info.path(), node_info.used_space.clone()).await?;
+        let chunks =
+            SequenceChunkStore::new(node_info.path(), node_info.used_space.clone()).await?;
         Ok(Self { chunks, wrapping })
     }
 

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -61,7 +61,7 @@ impl KeySection {
         elder_state: ElderState,
     ) -> Result<Self> {
         let gateway = ClientGateway::new(elder_state.clone()).await?;
-        let replicas = Self::transfer_replicas(node_info, elder_state.clone())?;
+        let replicas = Self::transfer_replicas(node_info, elder_state.clone());
         let transfers = Transfers::new(elder_state.clone(), replicas, rate_limit);
         let msg_analysis = ClientMsgAnalysis::new(elder_state.clone());
 
@@ -140,7 +140,7 @@ impl KeySection {
     fn transfer_replicas(
         node_info: &NodeInfo,
         elder_state: ElderState,
-    ) -> Result<Replicas<ReplicaSigningImpl>> {
+    ) -> Replicas<ReplicaSigningImpl> {
         let root_dir = node_info.root_dir.clone();
         let id = elder_state.public_key_share();
         let key_index = elder_state.key_index();

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -18,7 +18,7 @@ use self::{
 use crate::{
     capacity::RateLimit,
     node::node_ops::{KeySectionDuty, NodeOperation},
-    ElderState, Result,
+    ElderState, NodeInfo, Result,
 };
 use log::{info, trace};
 use sn_data_types::{PublicKey, TransferPropagated};
@@ -55,9 +55,9 @@ pub struct KeySection {
 }
 
 impl KeySection {
-    pub async fn new(rate_limit: RateLimit, elder_state: ElderState) -> Result<Self> {
+    pub async fn new(rate_limit: RateLimit, node_info: &NodeInfo, elder_state: ElderState) -> Result<Self> {
         let gateway = ClientGateway::new(elder_state.clone()).await?;
-        let replicas = Self::transfer_replicas(elder_state.clone())?;
+        let replicas = Self::transfer_replicas(node_info, elder_state.clone())?;
         let transfers = Transfers::new(elder_state.clone(), replicas, rate_limit);
         let msg_analysis = ClientMsgAnalysis::new(elder_state.clone());
 
@@ -133,8 +133,8 @@ impl KeySection {
         }
     }
 
-    fn transfer_replicas(elder_state: ElderState) -> Result<Replicas<ReplicaSigningImpl>> {
-        let root_dir = elder_state.info().root_dir.clone();
+    fn transfer_replicas(node_info: &NodeInfo, elder_state: ElderState) -> Result<Replicas<ReplicaSigningImpl>> {
+        let root_dir = node_info.root_dir.clone();
         let id = elder_state.public_key_share();
         let key_index = elder_state.key_index();
         let peer_replicas = elder_state.public_key_set().clone();

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -55,7 +55,11 @@ pub struct KeySection {
 }
 
 impl KeySection {
-    pub async fn new(rate_limit: RateLimit, node_info: &NodeInfo, elder_state: ElderState) -> Result<Self> {
+    pub async fn new(
+        rate_limit: RateLimit,
+        node_info: &NodeInfo,
+        elder_state: ElderState,
+    ) -> Result<Self> {
         let gateway = ClientGateway::new(elder_state.clone()).await?;
         let replicas = Self::transfer_replicas(node_info, elder_state.clone())?;
         let transfers = Transfers::new(elder_state.clone(), replicas, rate_limit);
@@ -133,7 +137,10 @@ impl KeySection {
         }
     }
 
-    fn transfer_replicas(node_info: &NodeInfo, elder_state: ElderState) -> Result<Replicas<ReplicaSigningImpl>> {
+    fn transfer_replicas(
+        node_info: &NodeInfo,
+        elder_state: ElderState,
+    ) -> Result<Replicas<ReplicaSigningImpl>> {
         let root_dir = node_info.root_dir.clone();
         let id = elder_state.public_key_share();
         let key_index = elder_state.key_index();

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -29,7 +29,11 @@ pub struct ElderDuties {
 }
 
 impl ElderDuties {
-    pub async fn new(wallet_info: WalletInfo, node_info: &NodeInfo, state: ElderState) -> Result<Self> {
+    pub async fn new(
+        wallet_info: WalletInfo,
+        node_info: &NodeInfo,
+        state: ElderState,
+    ) -> Result<Self> {
         let dbs = ChunkHolderDbs::new(node_info.path())?;
         let rate_limit = RateLimit::new(state.clone(), Capacity::new(dbs.clone()));
         let key_section = KeySection::new(rate_limit, node_info, state.clone()).await?;
@@ -131,7 +135,11 @@ impl ElderDuties {
     }
 
     ///
-    pub async fn finish_elder_change(&mut self, node_info: &NodeInfo, state: ElderState) -> Result<()> {
+    pub async fn finish_elder_change(
+        &mut self,
+        node_info: &NodeInfo,
+        state: ElderState,
+    ) -> Result<()> {
         // 2. Then we must update key section..
         let dbs = ChunkHolderDbs::new(node_info.path())?;
         let rate_limit = RateLimit::new(state.clone(), Capacity::new(dbs));

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -76,7 +76,6 @@ impl Node {
 
         let node_info = NodeInfo {
             genesis: config.is_first(),
-            node_id: PublicKey::Ed25519(network_api.public_key().await),
             root_dir: root_dir_buf,
             /// Upper limit in bytes for allowed network storage on this node.
             /// An Adult would be using the space for chunks,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -14,6 +14,7 @@ mod node_ops;
 pub mod state_db;
 
 use crate::{
+    chunk_store::UsedSpace,
     node::{
         node_duties::NodeDuties,
         node_ops::{GatewayDuty, NetworkDuty, NodeDuty, NodeOperation},
@@ -77,10 +78,7 @@ impl Node {
         let node_info = NodeInfo {
             genesis: config.is_first(),
             root_dir: root_dir_buf,
-            /// Upper limit in bytes for allowed network storage on this node.
-            /// An Adult would be using the space for chunks,
-            /// while an Elder uses it for metadata.
-            max_storage_capacity: config.max_capacity(),
+            used_space: UsedSpace::new(config.max_capacity()),
             reward_key,
         };
 

--- a/src/node/node_duties/elder_constellation.rs
+++ b/src/node/node_duties/elder_constellation.rs
@@ -31,7 +31,6 @@ use sn_routing::Prefix;
 
 ///
 pub struct ElderConstellation {
-    info: NodeInfo,
     network: Network,
     duties: ElderDuties,
     pending_changes: Vec<ConstellationChange>,
@@ -44,9 +43,8 @@ struct ConstellationChange {
 
 impl ElderConstellation {
     ///
-    pub fn new(info: NodeInfo, duties: ElderDuties, network: Network) -> Self {
+    pub fn new(duties: ElderDuties, network: Network) -> Self {
         Self {
-            info,
             network,
             duties,
             pending_changes: vec![],
@@ -97,6 +95,7 @@ impl ElderConstellation {
     ///
     pub async fn finish_elder_change(
         &mut self,
+        node_info: &NodeInfo,
         previous_key: PublicKey,
         new_key: PublicKey,
     ) -> Result<NodeOperation> {
@@ -124,7 +123,7 @@ impl ElderConstellation {
         // 3. And update key section with it.
         let _ = self
             .duties
-            .finish_elder_change(&self.info, new_elder_state.clone())
+            .finish_elder_change(node_info, new_elder_state.clone())
             .await?;
 
         debug!("Key section completed elder change update.");

--- a/src/node/node_duties/elder_constellation.rs
+++ b/src/node/node_duties/elder_constellation.rs
@@ -90,7 +90,7 @@ impl ElderConstellation {
         // 1. First we must update data section..
         // TODO: Query network for data corresponding to provided "new_section_key"!!!!
         // Otherwise there is no guarantee of not getting more recent info than expected!
-        let new_elder_state = ElderState::new(&self.info, self.network.clone()).await?;
+        let new_elder_state = ElderState::new(self.network.clone()).await?;
         self.duties.initiate_elder_change(new_elder_state).await
     }
 
@@ -120,11 +120,11 @@ impl ElderConstellation {
         // 2. We must load _current_ elder state..
         // TODO: Query network for data corresponding to provided "new_section_key"!!!!
         // Otherwise there is no guarantee of not getting more recent info than expected!
-        let new_elder_state = ElderState::new(&self.info, self.network.clone()).await?;
+        let new_elder_state = ElderState::new(self.network.clone()).await?;
         // 3. And update key section with it.
         let _ = self
             .duties
-            .finish_elder_change(new_elder_state.clone())
+            .finish_elder_change(&self.info, new_elder_state.clone())
             .await?;
 
         debug!("Key section completed elder change update.");

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -294,6 +294,7 @@ impl NodeDuties {
         info!("Assuming Adult duties..");
         let state = AdultState::new(self.network_api.clone()).await?;
         let duties = AdultDuties::new(&self.node_info, state).await?;
+        self.node_info.used_space.reset().await;
         self.stage = Stage::Adult(duties);
         info!("Adult duties assumed.");
         // NB: This is wrong, shouldn't write to disk here,
@@ -596,6 +597,7 @@ impl NodeDuties {
         }
 
         // 3. Set new stage
+        self.node_info.used_space.reset().await;
         self.stage = Stage::Elder(ElderConstellation::new(duties, self.network_api.clone()));
 
         // NB: This is wrong, shouldn't write to disk here,

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -252,7 +252,7 @@ impl NodeDuties {
         };
         let wrapping =
             NodeMsgWrapping::new(NodeState::Adult(adult_state), MsgNodeDuties::NodeConfig);
-        let node_id = self.node_info.node_id;
+        let node_id = PublicKey::from(self.network_api.public_key().await);
         wrapping
             .send_to_section(
                 Message::NodeCmd {

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -292,8 +292,8 @@ impl NodeDuties {
             return Ok(NodeOperation::NoOp);
         }
         info!("Assuming Adult duties..");
-        let state = AdultState::new(self.node_info.clone(), self.network_api.clone()).await?;
-        let duties = AdultDuties::new(state).await?;
+        let state = AdultState::new(self.network_api.clone()).await?;
+        let duties = AdultDuties::new(&self.node_info, state).await?;
         self.stage = Stage::Adult(duties);
         info!("Adult duties assumed.");
         // NB: This is wrong, shouldn't write to disk here,
@@ -652,8 +652,8 @@ impl NodeDuties {
             Stage::AccumulatingGenesis(_) => Ok(NodeOperation::NoOp), // TODO: Queue up (or something?)!!
             Stage::Adult(_old_state) => {
                 let state =
-                    AdultState::new(self.node_info.clone(), self.network_api.clone()).await?;
-                let duties = AdultDuties::new(state).await?;
+                    AdultState::new(self.network_api.clone()).await?;
+                let duties = AdultDuties::new(&self.node_info, state).await?;
                 self.stage = Stage::Adult(duties);
                 Ok(NodeOperation::NoOp)
             }

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -326,7 +326,7 @@ impl NodeDuties {
             // this is the case when we are the GENESIS_ELDER_COUNT-th Elder!
             debug!("threshold reached; proposing genesis!");
 
-            let elder_state = ElderState::new(&self.node_info, self.network_api.clone()).await?;
+            let elder_state = ElderState::new(self.network_api.clone()).await?;
             let genesis_balance = u32::MAX as u64 * 1_000_000_000;
             let credit = Credit {
                 id: Default::default(),
@@ -411,7 +411,7 @@ impl NodeDuties {
         let (stage, cmd) = match self.stage {
             Stage::AwaitingGenesisThreshold(ref mut queued_ops) => {
                 let elder_state =
-                    ElderState::new(&self.node_info, self.network_api.clone()).await?;
+                    ElderState::new(self.network_api.clone()).await?;
 
                 let mut signatures: BTreeMap<usize, bls::SignatureShare> = Default::default();
                 let _ = signatures.insert(sig.index, sig.share);
@@ -584,8 +584,8 @@ impl NodeDuties {
         trace!("Finishing transition to Elder..");
 
         let mut ops: Vec<NodeOperation> = vec![];
-        let state = ElderState::new(&self.node_info, self.network_api.clone()).await?;
-        let mut duties = ElderDuties::new(wallet_info, state.clone()).await?;
+        let state = ElderState::new(self.network_api.clone()).await?;
+        let mut duties = ElderDuties::new(wallet_info, &self.node_info, state.clone()).await?;
 
         // 1. Initiate duties.
         ops.push(duties.initiate(genesis).await?);


### PR DESCRIPTION
closes #1290 
fixes #1288 

There's a little bit of interleaving in fixing these two because `UsedSpace` was made a part of `NodeInfo`, so the one issue ended up depending in part on the other.