### PR TITLE
chore(clippy): Removes unused Result<T> & applies formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.26.8"
+version = "0.26.11"
 dependencies = [
  "async-log",
  "async-trait",
@@ -2432,7 +2432,6 @@ dependencies = [
  "tempdir",
  "thiserror",
  "threshold_crypto",
- "tiny-keccak 1.5.0",
  "tokio",
  "xor_name",
 ]

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -53,12 +53,12 @@ impl BlobRegister {
         dbs: ChunkHolderDbs,
         wrapping: ElderMsgWrapping,
         elder_state: ElderState,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             dbs,
             elder_state,
             wrapping,
-        })
+        }
     }
 
     pub(super) async fn write(

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -48,7 +48,7 @@ impl Metadata {
         elder_state: ElderState,
     ) -> Result<Self> {
         let wrapping = ElderMsgWrapping::new(elder_state.clone(), ElderDuties::Metadata);
-        let blob_register = BlobRegister::new(dbs, wrapping.clone(), elder_state)?;
+        let blob_register = BlobRegister::new(dbs, wrapping.clone(), elder_state);
         let map_storage = MapStorage::new(node_info, wrapping.clone()).await?;
         let sequence_storage = SequenceStorage::new(node_info, wrapping.clone()).await?;
         let elder_stores = ElderStores::new(blob_register, map_storage, sequence_storage);

--- a/src/node/elder_duties/data_section/rewards/reward_calc.rs
+++ b/src/node/elder_duties/data_section/rewards/reward_calc.rs
@@ -40,7 +40,7 @@ impl RewardCalc {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Result;
+    use crate::{Error, Result};
 
     #[test]
     fn first_reward_is_32bn_nanos() -> Result<()> {
@@ -48,7 +48,15 @@ mod test {
         let prefix_len = 1;
         let reward = RewardCalc::reward_from(age, prefix_len);
         assert!(reward == Token::from_nano(32_000_000_000));
-        Ok(())
+        let correct_token = Token::from_nano(32_000_000_000);
+        if reward != correct_token {
+            Err(Error::Logic(format!(
+                "Incorrect reward, expected {} == {}",
+                reward, correct_token
+            )))
+        } else {
+            Ok(())
+        }
     }
 
     #[test]
@@ -56,7 +64,14 @@ mod test {
         let age = 5;
         let prefix_len = 34;
         let reward = RewardCalc::reward_from(age, prefix_len);
-        assert!(reward >= Token::from_nano(1));
-        Ok(())
+        let correct_token = Token::from_nano(1);
+        if reward < correct_token {
+            Err(Error::Logic(format!(
+                "Incorrect reward calc, expected {} >= {}",
+                reward, correct_token,
+            )))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/node/elder_duties/key_section/client_msg_analysis.rs
+++ b/src/node/elder_duties/key_section/client_msg_analysis.rs
@@ -82,10 +82,13 @@ impl ClientMsgAnalysis {
     /// just send back the response, for the client to accumulate.
     async fn try_data(&self, msg: &MsgEnvelope) -> Result<NodeOperation> {
         let is_data_read = || {
-            matches!(msg.message, Message::Query {
-                query: Query::Data { .. },
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Query {
+                    query: Query::Data { .. },
+                    ..
+                }
+            )
         };
         let shall_process = || is_data_read() && msg.origin.is_client();
 
@@ -104,10 +107,13 @@ impl ClientMsgAnalysis {
     /// so there is no reason to accumulate it here.
     async fn try_data_payment(&self, msg: &MsgEnvelope) -> Result<NodeOperation> {
         let is_data_write = || {
-            matches!(msg.message, Message::Cmd {
-                cmd: Cmd::Data { .. },
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Cmd {
+                    cmd: Cmd::Data { .. },
+                    ..
+                }
+            )
         };
 
         let shall_process = || is_data_write() && msg.origin.is_client();

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -57,7 +57,7 @@ pub struct KeySection {
 impl KeySection {
     pub async fn new(rate_limit: RateLimit, elder_state: ElderState) -> Result<Self> {
         let gateway = ClientGateway::new(elder_state.clone()).await?;
-        let replicas = Self::transfer_replicas(elder_state.clone())?;
+        let replicas = Self::transfer_replicas(elder_state.clone());
         let transfers = Transfers::new(elder_state.clone(), replicas, rate_limit);
         let msg_analysis = ClientMsgAnalysis::new(elder_state.clone());
 
@@ -133,7 +133,7 @@ impl KeySection {
         }
     }
 
-    fn transfer_replicas(elder_state: ElderState) -> Result<Replicas<ReplicaSigningImpl>> {
+    fn transfer_replicas(elder_state: ElderState) -> Replicas<ReplicaSigningImpl> {
         let root_dir = elder_state.info().root_dir.clone();
         let id = elder_state.public_key_share();
         let key_index = elder_state.key_index();
@@ -147,7 +147,6 @@ impl KeySection {
             signing,
             initiating: true,
         };
-        let replica_manager = Replicas::new(root_dir, info)?;
-        Ok(replica_manager)
+        Replicas::new(root_dir, info)
     }
 }

--- a/src/node/elder_duties/key_section/transfers/replicas.rs
+++ b/src/node/elder_duties/key_section/transfers/replicas.rs
@@ -45,13 +45,13 @@ where
 }
 
 impl<T: ReplicaSigning> Replicas<T> {
-    pub(crate) fn new(root_dir: PathBuf, info: ReplicaInfo<T>) -> Result<Self> {
-        Ok(Self {
+    pub(crate) fn new(root_dir: PathBuf, info: ReplicaInfo<T>) -> Self {
+        Self {
             root_dir,
             info,
             locks: Default::default(),
             self_lock: Arc::new(Mutex::new(0)),
-        })
+        }
     }
 
     /// -----------------------------------------------------------------
@@ -604,7 +604,7 @@ mod test {
 
     #[test]
     fn section_actor_transition() -> Result<()> {
-        let (mut section, peer_replicas) = get_section(1)?;
+        let (mut section, peer_replicas) = get_section(1);
 
         let (genesis_replicas, mut genesis_actor) = section.remove(0);
         let _ = run(genesis_replicas.initiate(&[]))?;
@@ -627,7 +627,7 @@ mod test {
         }
 
         // Elders changed!
-        let (section, peer_replicas) = get_section(2)?;
+        let (section, peer_replicas) = get_section(2);
         let recipient = PublicKey::Bls(peer_replicas.public_key());
 
         // transfer the section funds to new section actor
@@ -727,7 +727,7 @@ mod test {
     }
 
     type Section = Vec<(Replicas<TestReplicaSigning>, Actor<Validator, Keypair>)>;
-    fn get_section(count: u8) -> Result<(Section, PublicKeySet)> {
+    fn get_section(count: u8) -> (Section, PublicKeySet) {
         let mut rng = rand::thread_rng();
         let threshold = count as usize - 1;
         let bls_secret_key = SecretKeySet::random(threshold, &mut rng);
@@ -738,7 +738,7 @@ mod test {
             .filter_map(|res| res.ok())
             .collect();
 
-        Ok((section, peer_replicas))
+        (section, peer_replicas)
     }
 
     fn get_replica(
@@ -758,7 +758,7 @@ mod test {
             initiating: true,
         };
         let root_dir = temp_dir()?;
-        let replicas = Replicas::new(root_dir.path().to_path_buf(), info)?;
+        let replicas = Replicas::new(root_dir.path().to_path_buf(), info);
 
         let keypair =
             Keypair::new_bls_share(0, bls_secret_key.secret_key_share(0), peer_replicas.clone());

--- a/src/node/node_duties/msg_analysis.rs
+++ b/src/node/node_duties/msg_analysis.rs
@@ -264,10 +264,13 @@ impl NetworkMsgAnalysis {
     async fn try_metadata(&self, msg: &MsgEnvelope) -> Result<MetadataDuty> {
         trace!("Msg analysis: try_metadata..");
         let is_data_cmd = || {
-            matches!(msg.message, Message::Cmd {
-                cmd: Cmd::Data { .. },
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Cmd {
+                    cmd: Cmd::Data { .. },
+                    ..
+                }
+            )
         };
         let sender = msg.most_recent_sender();
         let dst = msg.destination()?;
@@ -282,10 +285,13 @@ impl NetworkMsgAnalysis {
         };
 
         let is_data_query = || {
-            matches!(msg.message, Message::Query {
-                query: Query::Data(_),
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Query {
+                    query: Query::Data(_),
+                    ..
+                }
+            )
         };
         let from_single_gateway_elder = || {
             msg.most_recent_sender().is_elder() && matches!(duty, Duty::Elder(ElderDuties::Gateway))
@@ -323,18 +329,23 @@ impl NetworkMsgAnalysis {
 
         // TODO: Should not accumulate queries, just pass them through.
         let is_chunk_query = || {
-            matches!(msg.message, Message::Query {
-                query: Query::Data(DataQuery::Blob(_)),
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Query {
+                    query: Query::Data(DataQuery::Blob(_)),
+                    ..
+                }
+            )
         };
 
         let is_chunk_cmd = || {
-            matches!(msg.message,
-            Message::NodeCmd {
-                cmd:NodeCmd::Data(NodeDataCmd::Blob(_)),
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::NodeCmd {
+                    cmd: NodeCmd::Data(NodeDataCmd::Blob(_)),
+                    ..
+                }
+            )
         };
 
         let shall_process =


### PR DESCRIPTION
fixes #1293 

There's a new Cargo version, which changes the behavior of `rust-fmt` and adds some lints to `clippy` which cause CI to fail. This patch removes some unused `Result<T>` as well as fixing some general formatting.