### PR TITLE
Flag to clear data of previous running node + code improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.26.8"
+version = "0.26.11"
 dependencies = [
  "async-log",
  "async-trait",
@@ -2432,7 +2432,6 @@ dependencies = [
  "tempdir",
  "thiserror",
  "threshold_crypto",
- "tiny-keccak 1.5.0",
  "tokio",
  "xor_name",
 ]

--- a/src/capacity/rate_limit.rs
+++ b/src/capacity/rate_limit.rs
@@ -80,23 +80,21 @@ impl RateLimit {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Result;
     use sn_messaging::client::DataCmd;
     use std::mem;
 
     #[test]
-    fn calculates_rate_limit() -> Result<()> {
+    fn calculates_rate_limit() {
         let bytes = 1_000;
         let prefix_len = 0;
         let all_nodes = 8;
         let full_nodes = 7;
         let rate_limit = RateLimit::rate_limit(bytes, full_nodes, all_nodes, prefix_len).as_nano();
         assert_eq!(rate_limit, 2076594);
-        Ok(())
     }
 
     #[test]
-    fn calculates_max_section_nanos() -> Result<()> {
+    fn calculates_max_section_nanos() {
         // prefix zero is one section so is responsible for all tokens
         let first_section_nanos = RateLimit::max_section_nanos(0);
         assert_eq!(MAX_SUPPLY, first_section_nanos);
@@ -106,7 +104,6 @@ mod test {
         // some tokens remain in section up to 2.6 * 10^18 sections, (which is more than one billion times one billion sections).
         let last_split_nanos = RateLimit::max_section_nanos(61);
         assert!(last_split_nanos > 0);
-        Ok(())
     }
 
     // -------------------------------------------------------------
@@ -116,7 +113,7 @@ mod test {
     // These tests are of the type 'all things being equal, then ...'
 
     #[test]
-    fn rate_limit_smaller_chunks_cost_less() -> Result<()> {
+    fn rate_limit_smaller_chunks_cost_less() {
         // setup
         let one_mb_bytes = 1024 * 1024;
         let prefix_len = 0;
@@ -135,11 +132,10 @@ mod test {
             small,
             standard_rl
         );
-        Ok(())
     }
 
     #[test]
-    fn rate_limit_larger_net_is_cheaper() -> Result<()> {
+    fn rate_limit_larger_net_is_cheaper() {
         // setup
         let one_mb_bytes = 1024 * 1024;
         let prefix_len = 2; // first couple of sections see an increase in cost, whereafter it is strictly decreasing
@@ -157,11 +153,10 @@ mod test {
             big,
             standard_rl
         );
-        Ok(())
     }
 
     #[test]
-    fn rate_limit_emptier_section_is_cheaper() -> Result<()> {
+    fn rate_limit_emptier_section_is_cheaper() {
         // setup
         let one_mb_bytes = 1024 * 1024;
         let prefix_len = 0;
@@ -179,12 +174,11 @@ mod test {
             empty,
             standard_rl
         );
-        Ok(())
     }
 
     #[test]
     #[ignore] // these tests fail with the current implementation
-    fn rate_limit_single_store_is_cheaper_than_same_bytes_over_multiple() -> Result<()> {
+    fn rate_limit_single_store_is_cheaper_than_same_bytes_over_multiple() {
         // setup
         let one_mb_bytes = 1024 * 1024;
         let prefix_len = 0;
@@ -203,11 +197,10 @@ mod test {
             standard_rl,
             combined
         );
-        Ok(())
     }
 
     #[test]
-    fn rate_limit_is_applied_up_to_3400_billion_nodes() -> Result<()> {
+    fn rate_limit_is_applied_up_to_3400_billion_nodes() {
         // setup
         // The size of the actual DataCmd
         // is used for storecost calc,
@@ -230,12 +223,11 @@ mod test {
             endcost > 0,
             "cost is not greater than zero up to 3400 billion nodes",
         );
-        Ok(())
     }
 
     #[test]
     #[ignore] // this test fails under the current assumptions (max network size is not realistic)
-    fn rate_limit_is_applied_up_to_max_network_size() -> Result<()> {
+    fn rate_limit_is_applied_up_to_max_network_size() {
         // setup
         // The size of the actual DataCmd
         // is used for storecost calc,
@@ -259,11 +251,10 @@ mod test {
             "cost is not always greater than zero: cost is {}",
             endcost
         );
-        Ok(())
     }
 
     #[test]
-    fn rate_limit_first_chunk_has_a_reasonable_cost() -> Result<()> {
+    fn rate_limit_first_chunk_has_a_reasonable_cost() {
         // setup
         let one_mb_bytes = 1024 * 1024;
         let max_initial_cost = 1_000 * 1_000_000_000; // 1000 tokens
@@ -284,6 +275,5 @@ mod test {
             startcost,
             max_initial_cost
         );
-        Ok(())
     }
 }

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -53,12 +53,12 @@ impl BlobRegister {
         dbs: ChunkHolderDbs,
         wrapping: ElderMsgWrapping,
         elder_state: ElderState,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             dbs,
             elder_state,
             wrapping,
-        })
+        }
     }
 
     pub(super) async fn write(

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -48,7 +48,7 @@ impl Metadata {
         elder_state: ElderState,
     ) -> Result<Self> {
         let wrapping = ElderMsgWrapping::new(elder_state.clone(), ElderDuties::Metadata);
-        let blob_register = BlobRegister::new(dbs, wrapping.clone(), elder_state)?;
+        let blob_register = BlobRegister::new(dbs, wrapping.clone(), elder_state);
         let map_storage = MapStorage::new(node_info, wrapping.clone()).await?;
         let sequence_storage = SequenceStorage::new(node_info, wrapping.clone()).await?;
         let elder_stores = ElderStores::new(blob_register, map_storage, sequence_storage);

--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -157,7 +157,7 @@ impl Rewards {
                     self.section_funds.synch(info.history).await?.into()
                 }
             }
-            AddNewNode(node_id) => self.add_new_node(node_id)?.into(),
+            AddNewNode(node_id) => self.add_new_node(node_id).into(),
             SetNodeWallet { node_id, wallet_id } => {
                 self.set_node_wallet(node_id, wallet_id)?.into()
             }
@@ -245,10 +245,10 @@ impl Rewards {
     /// It still hasn't registered a wallet id at
     /// this point, but will as part of starting up.
     /// At age 5 it gets its first reward payout.
-    fn add_new_node(&self, node_id: XorName) -> Result<NodeMessagingDuty> {
+    fn add_new_node(&self, node_id: XorName) -> NodeMessagingDuty {
         info!("Rewards: New node added: {:?}", node_id);
         let _ = self.node_rewards.insert(node_id, NodeRewards::NewNode);
-        Ok(NodeMessagingDuty::NoOp)
+        NodeMessagingDuty::NoOp
     }
 
     /// 1. A new node registers a wallet id for future reward payout.

--- a/src/node/elder_duties/data_section/rewards/reward_calc.rs
+++ b/src/node/elder_duties/data_section/rewards/reward_calc.rs
@@ -40,23 +40,20 @@ impl RewardCalc {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Result;
 
     #[test]
-    fn first_reward_is_32bn_nanos() -> Result<()> {
+    fn first_reward_is_32bn_nanos() {
         let age = 5;
         let prefix_len = 1;
         let reward = RewardCalc::reward_from(age, prefix_len);
         assert!(reward == Token::from_nano(32_000_000_000));
-        Ok(())
     }
 
     #[test]
-    fn min_reward_payable_up_to_at_least_2000bn_nodes() -> Result<()> {
+    fn min_reward_payable_up_to_at_least_2000bn_nodes() {
         let age = 5;
         let prefix_len = 34;
         let reward = RewardCalc::reward_from(age, prefix_len);
         assert!(reward >= Token::from_nano(1));
-        Ok(())
     }
 }

--- a/src/node/elder_duties/key_section/client_msg_analysis.rs
+++ b/src/node/elder_duties/key_section/client_msg_analysis.rs
@@ -82,10 +82,13 @@ impl ClientMsgAnalysis {
     /// just send back the response, for the client to accumulate.
     async fn try_data(&self, msg: &MsgEnvelope) -> Result<NodeOperation> {
         let is_data_read = || {
-            matches!(msg.message, Message::Query {
-                query: Query::Data { .. },
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Query {
+                    query: Query::Data { .. },
+                    ..
+                }
+            )
         };
         let shall_process = || is_data_read() && msg.origin.is_client();
 
@@ -104,10 +107,13 @@ impl ClientMsgAnalysis {
     /// so there is no reason to accumulate it here.
     async fn try_data_payment(&self, msg: &MsgEnvelope) -> Result<NodeOperation> {
         let is_data_write = || {
-            matches!(msg.message, Message::Cmd {
-                cmd: Cmd::Data { .. },
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Cmd {
+                    cmd: Cmd::Data { .. },
+                    ..
+                }
+            )
         };
 
         let shall_process = || is_data_write() && msg.origin.is_client();

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -57,7 +57,7 @@ pub struct KeySection {
 impl KeySection {
     pub async fn new(rate_limit: RateLimit, elder_state: ElderState) -> Result<Self> {
         let gateway = ClientGateway::new(elder_state.clone()).await?;
-        let replicas = Self::transfer_replicas(elder_state.clone())?;
+        let replicas = Self::transfer_replicas(elder_state.clone());
         let transfers = Transfers::new(elder_state.clone(), replicas, rate_limit);
         let msg_analysis = ClientMsgAnalysis::new(elder_state.clone());
 
@@ -133,7 +133,7 @@ impl KeySection {
         }
     }
 
-    fn transfer_replicas(elder_state: ElderState) -> Result<Replicas<ReplicaSigningImpl>> {
+    fn transfer_replicas(elder_state: ElderState) -> Replicas<ReplicaSigningImpl> {
         let root_dir = elder_state.info().root_dir.clone();
         let id = elder_state.public_key_share();
         let key_index = elder_state.key_index();
@@ -147,7 +147,6 @@ impl KeySection {
             signing,
             initiating: true,
         };
-        let replica_manager = Replicas::new(root_dir, info)?;
-        Ok(replica_manager)
+        Replicas::new(root_dir, info)
     }
 }

--- a/src/node/elder_duties/key_section/transfers/replicas.rs
+++ b/src/node/elder_duties/key_section/transfers/replicas.rs
@@ -45,13 +45,13 @@ where
 }
 
 impl<T: ReplicaSigning> Replicas<T> {
-    pub(crate) fn new(root_dir: PathBuf, info: ReplicaInfo<T>) -> Result<Self> {
-        Ok(Self {
+    pub(crate) fn new(root_dir: PathBuf, info: ReplicaInfo<T>) -> Self {
+        Self {
             root_dir,
             info,
             locks: Default::default(),
             self_lock: Arc::new(Mutex::new(0)),
-        })
+        }
     }
 
     /// -----------------------------------------------------------------
@@ -758,7 +758,7 @@ mod test {
             initiating: true,
         };
         let root_dir = temp_dir()?;
-        let replicas = Replicas::new(root_dir.path().to_path_buf(), info)?;
+        let replicas = Replicas::new(root_dir.path().to_path_buf(), info);
 
         let keypair =
             Keypair::new_bls_share(0, bls_secret_key.secret_key_share(0), peer_replicas.clone());

--- a/src/node/elder_duties/key_section/transfers/replicas.rs
+++ b/src/node/elder_duties/key_section/transfers/replicas.rs
@@ -604,7 +604,7 @@ mod test {
 
     #[test]
     fn section_actor_transition() -> Result<()> {
-        let (mut section, peer_replicas) = get_section(1)?;
+        let (mut section, peer_replicas) = get_section(1);
 
         let (genesis_replicas, mut genesis_actor) = section.remove(0);
         let _ = run(genesis_replicas.initiate(&[]))?;
@@ -627,7 +627,7 @@ mod test {
         }
 
         // Elders changed!
-        let (section, peer_replicas) = get_section(2)?;
+        let (section, peer_replicas) = get_section(2);
         let recipient = PublicKey::Bls(peer_replicas.public_key());
 
         // transfer the section funds to new section actor
@@ -727,7 +727,7 @@ mod test {
     }
 
     type Section = Vec<(Replicas<TestReplicaSigning>, Actor<Validator, Keypair>)>;
-    fn get_section(count: u8) -> Result<(Section, PublicKeySet)> {
+    fn get_section(count: u8) -> (Section, PublicKeySet) {
         let mut rng = rand::thread_rng();
         let threshold = count as usize - 1;
         let bls_secret_key = SecretKeySet::random(threshold, &mut rng);
@@ -738,7 +738,7 @@ mod test {
             .filter_map(|res| res.ok())
             .collect();
 
-        Ok((section, peer_replicas))
+        (section, peer_replicas)
     }
 
     fn get_replica(

--- a/src/node/node_duties/msg_analysis.rs
+++ b/src/node/node_duties/msg_analysis.rs
@@ -264,10 +264,13 @@ impl NetworkMsgAnalysis {
     async fn try_metadata(&self, msg: &MsgEnvelope) -> Result<MetadataDuty> {
         trace!("Msg analysis: try_metadata..");
         let is_data_cmd = || {
-            matches!(msg.message, Message::Cmd {
-                cmd: Cmd::Data { .. },
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Cmd {
+                    cmd: Cmd::Data { .. },
+                    ..
+                }
+            )
         };
         let sender = msg.most_recent_sender();
         let dst = msg.destination()?;
@@ -282,10 +285,13 @@ impl NetworkMsgAnalysis {
         };
 
         let is_data_query = || {
-            matches!(msg.message, Message::Query {
-                query: Query::Data(_),
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Query {
+                    query: Query::Data(_),
+                    ..
+                }
+            )
         };
         let from_single_gateway_elder = || {
             msg.most_recent_sender().is_elder() && matches!(duty, Duty::Elder(ElderDuties::Gateway))
@@ -323,18 +329,23 @@ impl NetworkMsgAnalysis {
 
         // TODO: Should not accumulate queries, just pass them through.
         let is_chunk_query = || {
-            matches!(msg.message, Message::Query {
-                query: Query::Data(DataQuery::Blob(_)),
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::Query {
+                    query: Query::Data(DataQuery::Blob(_)),
+                    ..
+                }
+            )
         };
 
         let is_chunk_cmd = || {
-            matches!(msg.message,
-            Message::NodeCmd {
-                cmd:NodeCmd::Data(NodeDataCmd::Blob(_)),
-                ..
-            })
+            matches!(
+                msg.message,
+                Message::NodeCmd {
+                    cmd: NodeCmd::Data(NodeDataCmd::Blob(_)),
+                    ..
+                }
+            )
         };
 
         let shall_process =


### PR DESCRIPTION
- Added flag to clear data of previous node running on same PC

- Removed hard coded integral constants like `ARGS[18]` (hardly
maintainable, you have to count elements in ARGS array to check what
an index stands for)

  The situation is better now (no index values to manage anymore) but not
perfect. The problem is that I don't understand why arguments are
analyzed this way. This forces the creation of an array that duplicates
the structure used to define the arguments.

  Normally with structopt we don't need to do that.

- Corrected some clippy and fmt errors.