### PR TITLE
chore(ci): update pr_size_checker to v2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,7 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: maidsafe/pr_size_checker@v1.1
+      with:
+        fetch-depth: '0'
+    - uses: maidsafe/pr_size_checker@v2
       with:
         max_lines_changed: 200
   


### PR DESCRIPTION
Will mean cargo.lock is no longer included in the count