### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,8 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.9.24"
-source = "git+https://github.com/bochaco/qp2p.git?branch=upgrade-tokio#8d4dc3e2b3d8c9937ed99b6392040386630bdbab"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844273c97032bf05fa2158d5420cc4823f20157af6982b913c27b44dc612d7db"
 dependencies = [
  "base64 0.12.3",
  "bincode",
@@ -2316,9 +2317,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sn_data_types"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7a48501ca366db81e4e11a0f42255a095a9ff3c2461d4dd484d25b82978e5b"
+checksum = "474a9777c2d8f79ceaf4a4c3224269132a14e74ed3404e726a4bf23b2ed13f68"
 dependencies = [
  "bincode",
  "crdts",
@@ -2350,35 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "sn_messaging"
-version = "6.0.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639ec9bf6175a0a68a559a6e8f3ff8b4d4b155a4df124051c3fafb18b5a1bdde"
-dependencies = [
- "bincode",
- "bytes 1.0.1",
- "cookie-factory",
- "crdts",
- "ed25519-dalek",
- "hex_fmt",
- "multibase",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "rmp-serde",
- "serde",
- "serde_bytes",
- "signature",
- "sn_data_types",
- "thiserror",
- "threshold_crypto",
- "tiny-keccak 2.0.2",
- "xor_name",
-]
-
-[[package]]
-name = "sn_messaging"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6bb5907bbfbbe96961cb42a7683492b032e980a35b585c95f180a283a8c9ad8"
+checksum = "2119f03b71982b5165f24b7cb28af8fd39e12f7c1d779891a9b9c9d608130433"
 dependencies = [
  "bincode",
  "bytes 1.0.1",
@@ -2402,11 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-<<<<<<< HEAD
-version = "0.28.1"
-=======
-version = "0.28.0"
->>>>>>> chore(tokio): upgrade tokio to v1.2.0
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-log",
@@ -2438,7 +2409,7 @@ dependencies = [
  "signature",
  "sn_data_types",
  "sn_launch_tool",
- "sn_messaging 6.0.1",
+ "sn_messaging",
  "sn_routing",
  "sn_transfers",
  "structopt",
@@ -2451,8 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "sn_routing"
-version = "0.47.2"
-source = "git+https://github.com/bochaco/sn_routing.git?branch=upgrade-tokio#305ea7ce84534eef9a399f5a25765c84a26043db"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00172c56a9614a79e1670cc99170a3ffb8dfd9a209ae6c21ba159441419e03c3"
 dependencies = [
  "bincode",
  "bls_dkg",
@@ -2469,7 +2441,7 @@ dependencies = [
  "resource_proof",
  "serde",
  "sn_data_types",
- "sn_messaging 7.0.0",
+ "sn_messaging",
  "thiserror",
  "threshold_crypto",
  "tiny-keccak 2.0.2",
@@ -2480,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "sn_transfers"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e38e3fe7051af3d6cd8515ae0ad8f841bd49a83ca784a62a51f7731576d951"
+checksum = "c3a21fadc04cc66d65c98d6f4e138f991ada27d4225c63041cf5351089969875"
 dependencies = [
  "bincode",
  "crdts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,13 +122,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "3a4c64e223db1fffa7683a719921434caa880463cfa5820032b063c9ecd5cc49"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "bls_dkg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b27bf5e841ae931b711ea4601c00e34d50a0d2acb9b433332df6447980f31fe"
+checksum = "c70896a0cf9bceb63481b1e42314c58529e45a8dadf073a3265401c1b5760832"
 dependencies = [
  "aes",
  "anyhow",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "bls_signature_aggregator"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7168aedec1ba6ca29bae8102cff1635da47a594570d77fc1451066ab78394165"
+checksum = "6f078a529a20765beda0a461d1353ef6b108b3f73fde0474e77d8ad268e54055"
 dependencies = [
  "serde",
  "thiserror",
@@ -508,7 +508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -558,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
 dependencies = [
  "data-encoding",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -714,7 +714,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
  "synstructure",
 ]
 
@@ -740,7 +740,7 @@ dependencies = [
  "num-traits",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -878,7 +878,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.5",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8405c7ed7db2948e8876e7b53e8ec8051682be5b3ac00e5429f0eab5e6dbaa5"
+checksum = "991058cf0e7f161b37a4a610ddbada9d2f051d0db76369b973de9f3466f1cba3"
 
 [[package]]
 name = "maplit"
@@ -1625,7 +1625,7 @@ checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -1636,9 +1636,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf491442e4b033ed1c722cb9f0df5fcfcf4de682466c46469c36bc47dc5548a"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1661,7 +1661,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
  "version_check",
 ]
 
@@ -2051,7 +2051,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.5",
+ "pin-project-lite 0.2.6",
  "rustls 0.18.1",
  "serde",
  "serde_json",
@@ -2252,7 +2252,7 @@ checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -2338,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.0.18"
+version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065ca5631a3cac1b922296f3739cda2964d66a78f113d9eace258be970839be6"
+checksum = "c88cc07a0dcdfcdbe79437d8fec9669a79f901cc9b3a07fdd1f7ca5411c91244"
 dependencies = [
  "directories",
  "env_logger 0.8.3",
@@ -2512,7 +2512,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -2534,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -2551,7 +2551,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
  "unicode-xid 0.2.1",
 ]
 
@@ -2647,7 +2647,7 @@ checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -2752,7 +2752,7 @@ dependencies = [
  "memchr",
  "mio 0.7.9",
  "num_cpus",
- "pin-project-lite 0.2.5",
+ "pin-project-lite 0.2.6",
  "tokio-macros",
 ]
 
@@ -2764,7 +2764,7 @@ checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -2803,7 +2803,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.5",
+ "pin-project-lite 0.2.6",
  "tokio 1.2.0",
 ]
 
@@ -2821,7 +2821,7 @@ checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.5",
+ "pin-project-lite 0.2.6",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2834,7 +2834,7 @@ checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
 ]
 
 [[package]]
@@ -3003,7 +3003,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -3037,7 +3037,7 @@ checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3171,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "xor_name"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea259e8f54c31d8088fea71fa315456b6cedaa5851ec3fafbe9daca49c6884f6"
+checksum = "b4987d7748c7907cc296e40cc89577ba3b19d339ae12ba529c9f16cb1fb0e845"
 dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -3222,7 +3222,7 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.60",
+ "syn 1.0.61",
  "synstructure",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler32"
@@ -127,19 +127,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "attohttpc"
-version = "0.10.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf13118df3e3dce4b5ac930641343b91b656e4e72c8f8325838b01a4b1c9d45"
+checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
 dependencies = [
  "http",
  "log",
  "url",
+ "wildmatch",
 ]
 
 [[package]]
@@ -168,7 +169,7 @@ dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.4.3",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -200,12 +201,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -218,9 +213,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
  "serde",
@@ -268,7 +263,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -292,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "bls_dkg"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d203a2483eb0c887d8c2fd197069094032639b86dfb827451b2a27b2d4e6526"
+checksum = "5b27bf5e841ae931b711ea4601c00e34d50a0d2acb9b433332df6447980f31fe"
 dependencies = [
  "aes",
  "anyhow",
@@ -313,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "bls_signature_aggregator"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a72582c101f1a8b2916177695103f8c4cbff29ee8219f1fe0b215651298d77"
+checksum = "7168aedec1ba6ca29bae8102cff1635da47a594570d77fc1451066ab78394165"
 dependencies = [
  "serde",
  "thiserror",
@@ -325,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byte-tools"
@@ -337,9 +332,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -368,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -491,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -512,7 +507,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
 dependencies = [
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -577,11 +572,10 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "2.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
 dependencies = [
- "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -685,25 +679,21 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
  "atty",
  "humantime",
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "err-derive"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "rustversion",
- "syn 1.0.60",
- "synstructure",
 ]
 
 [[package]]
@@ -723,7 +713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "synstructure",
 ]
@@ -749,7 +739,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -761,7 +751,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
  "winapi 0.3.9",
 ]
 
@@ -801,9 +791,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
@@ -833,9 +823,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -848,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -858,15 +848,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -875,42 +865,39 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -919,7 +906,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -937,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
@@ -1013,10 +1000,29 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.2.0",
+ "tokio-util 0.6.3",
+ "tracing",
 ]
 
 [[package]]
@@ -1083,6 +1089,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,12 +1112,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1113,15 +1126,39 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
- "tokio",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.1",
+ "http",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio 1.2.0",
  "tower-service",
  "tracing",
  "want",
@@ -1152,19 +1189,19 @@ checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes 0.5.6",
  "futures-util",
- "hyper",
+ "hyper 0.13.10",
  "log",
  "rustls 0.18.1",
- "tokio",
+ "tokio 0.2.25",
  "tokio-rustls",
  "webpki",
 ]
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1173,18 +1210,18 @@ dependencies = [
 
 [[package]]
 name = "igd"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd32c880165b2f776af0b38d206d1cabaebcf46c166ac6ae004a5d45f7d48ef"
+checksum = "4c4e7ee8b51e541486d7040883fe1f00e2a9954bcc24fd155b7e4f03ed4b93dd"
 dependencies = [
  "attohttpc",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures",
  "http",
- "hyper",
+ "hyper 0.14.4",
  "log",
- "rand 0.7.3",
- "tokio",
+ "rand 0.8.3",
+ "tokio 1.2.0",
  "url",
  "xmltree",
 ]
@@ -1252,9 +1289,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1283,9 +1320,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "linked-hash-map"
@@ -1305,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce7a913007f8d825242cd5017962f09bc3f19f91a382498c1e6756c842e3908"
+checksum = "e8405c7ed7db2948e8876e7b53e8ec8051682be5b3ac00e5429f0eab5e6dbaa5"
 
 [[package]]
 name = "maplit"
@@ -1354,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1375,10 +1412,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1391,6 +1441,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1412,6 +1472,15 @@ checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1475,9 +1544,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1505,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
  "base64 0.13.0",
  "once_cell",
@@ -1541,31 +1610,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
-dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.5",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -1575,21 +1624,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "0cf491442e4b033ed1c722cb9f0df5fcfcf4de682466c46469c36bc47dc5548a"
 
 [[package]]
 name = "pin-utils"
@@ -1611,7 +1660,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "version_check",
 ]
@@ -1623,7 +1672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "version_check",
 ]
 
@@ -1659,9 +1708,8 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.9.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9942ea11e9a97d6cf9a533960663c5ab049078e17e40ba7ea1491fb1675b15"
+version = "0.9.24"
+source = "git+https://github.com/bochaco/qp2p.git?branch=upgrade-tokio#8d4dc3e2b3d8c9937ed99b6392040386630bdbab"
 dependencies = [
  "base64 0.12.3",
  "bincode",
@@ -1672,12 +1720,12 @@ dependencies = [
  "log",
  "quinn",
  "rcgen",
- "rustls 0.17.0",
+ "rustls 0.19.0",
  "serde",
  "serde_json",
  "structopt",
  "thiserror",
- "tokio",
+ "tokio 1.2.0",
  "webpki",
 ]
 
@@ -1702,7 +1750,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -1710,34 +1758,37 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
+checksum = "624cfcfa9fcfc826945183ecd4a613480f67a1cf6b55d9d8df0d43bf3c12e951"
 dependencies = [
- "bytes 0.5.6",
- "err-derive",
+ "bytes 1.0.1",
  "futures",
+ "lazy_static",
  "libc",
- "mio",
+ "mio 0.7.9",
  "quinn-proto",
- "rustls 0.17.0",
- "tokio",
+ "rustls 0.19.0",
+ "socket2",
+ "thiserror",
+ "tokio 1.2.0",
  "tracing",
  "webpki",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
+checksum = "819acc105414fe4eacc122dc6a59d39b9b65915e66b8f7a787a9490c9d71e836"
 dependencies = [
- "bytes 0.5.6",
- "err-derive",
- "rand 0.7.3",
+ "bytes 1.0.1",
+ "rand 0.8.3",
  "ring",
- "rustls 0.17.0",
+ "rustls 0.19.0",
  "slab",
+ "thiserror",
+ "tinyvec",
  "tracing",
  "webpki",
 ]
@@ -1753,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
@@ -1913,9 +1964,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1926,7 +1977,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
 ]
 
 [[package]]
@@ -1947,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
 ]
 
 [[package]]
@@ -1989,8 +2040,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -1999,12 +2050,12 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "rustls 0.18.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.25",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
@@ -2043,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.10"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -2053,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "0.15.4"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839395ef53057db96b84c9238ab29e1a13f2e5c8ec9f66bef853ab4197303924"
+checksum = "3f74489002493a9984ee753ebd049552a1c82f0740e347ee9fc57c907fb19f83"
 dependencies = [
  "byteorder",
  "rmp",
@@ -2082,19 +2133,6 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
-dependencies = [
- "base64 0.11.0",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
@@ -2107,10 +2145,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.4"
+name = "rustls"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
 
 [[package]]
 name = "ryu"
@@ -2205,15 +2250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2271,13 +2316,12 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sn_data_types"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2bc7416afcca09b04b434eace1f29ac5cbf30c00b66696398da7d2e53f927"
+checksum = "dd7a48501ca366db81e4e11a0f42255a095a9ff3c2461d4dd484d25b82978e5b"
 dependencies = [
  "bincode",
  "crdts",
- "ed25519",
  "ed25519-dalek",
  "hex_fmt",
  "multibase",
@@ -2293,12 +2337,12 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.0.15"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64736f72a84269a0206c5a4f3a21ef83848e1b036a7ed0630f28102b0af8ffb"
+checksum = "065ca5631a3cac1b922296f3739cda2964d66a78f113d9eace258be970839be6"
 dependencies = [
  "directories",
- "env_logger",
+ "env_logger 0.8.3",
  "log",
  "serde_json",
  "structopt",
@@ -2331,9 +2375,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "sn_node"
-version = "0.28.1"
+name = "sn_messaging"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bb5907bbfbbe96961cb42a7683492b032e980a35b585c95f180a283a8c9ad8"
 dependencies = [
+ "bincode",
+ "bytes 1.0.1",
+ "cookie-factory",
+ "crdts",
+ "ed25519-dalek",
+ "hex_fmt",
+ "multibase",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "signature",
+ "sn_data_types",
+ "thiserror",
+ "threshold_crypto",
+ "tiny-keccak 2.0.2",
+ "xor_name",
+]
+
+[[package]]
+name = "sn_node"
+<<<<<<< HEAD
+version = "0.28.1"
+=======
+version = "0.28.0"
+>>>>>>> chore(tokio): upgrade tokio to v1.2.0
+dependencies = [
+ "anyhow",
  "async-log",
  "async-trait",
  "base64 0.10.1",
@@ -2363,22 +2438,21 @@ dependencies = [
  "signature",
  "sn_data_types",
  "sn_launch_tool",
- "sn_messaging",
+ "sn_messaging 6.0.1",
  "sn_routing",
  "sn_transfers",
  "structopt",
  "tempdir",
  "thiserror",
  "threshold_crypto",
- "tokio",
+ "tokio 1.2.0",
  "xor_name",
 ]
 
 [[package]]
 name = "sn_routing"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5480bad2f6aebf5ea245022fc705e240d96b2749775e69971d8180c4c4a650ef"
+version = "0.47.2"
+source = "git+https://github.com/bochaco/sn_routing.git?branch=upgrade-tokio#305ea7ce84534eef9a399f5a25765c84a26043db"
 dependencies = [
  "bincode",
  "bls_dkg",
@@ -2395,20 +2469,20 @@ dependencies = [
  "resource_proof",
  "serde",
  "sn_data_types",
- "sn_messaging",
+ "sn_messaging 7.0.0",
  "thiserror",
  "threshold_crypto",
  "tiny-keccak 2.0.2",
- "tokio",
+ "tokio 1.2.0",
  "tracing",
  "xor_name",
 ]
 
 [[package]]
 name = "sn_transfers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c6410c7870b371fc5ae407113c8ecd870bbdd6252bb84b26af9c2ed8ef5ddb"
+checksum = "77e38e3fe7051af3d6cd8515ae0ad8f841bd49a83ca784a62a51f7731576d951"
 dependencies = [
  "bincode",
  "crdts",
@@ -2465,7 +2539,7 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2493,7 +2567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "unicode-xid 0.2.1",
 ]
 
@@ -2504,16 +2578,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0313546c01d59e29be4f09687bcb4fb6690cec931cc3607b6aec7a0e417f4cc6"
+checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
 dependencies = [
  "filetime",
  "libc",
@@ -2539,7 +2613,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2571,7 +2645,7 @@ checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
  "redox_termios",
 ]
 
@@ -2586,21 +2660,21 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2688,21 +2762,36 @@ dependencies = [
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.9",
+ "num_cpus",
+ "pin-project-lite 0.2.5",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2714,7 +2803,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls 0.18.1",
- "tokio",
+ "tokio 0.2.25",
  "webpki",
 ]
 
@@ -2728,8 +2817,22 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
- "tokio",
+ "pin-project-lite 0.1.12",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.5",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -2740,25 +2843,25 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
 ]
 
@@ -2773,11 +2876,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project",
  "tracing",
 ]
 
@@ -2852,9 +2955,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2907,9 +3010,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2919,24 +3022,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2946,22 +3049,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
- "quote 1.0.8",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -2969,15 +3072,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3001,6 +3104,12 @@ checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2399814fda0d6999a6bfe9b5c7660d836334deb162a09db8b73d5b38fd8c40a"
 
 [[package]]
 name = "winapi"
@@ -3090,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "xor_name"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d821f4677b0bcd3cc1b0d7c622f11efbe7193843525faf541a4540fb0a78a27f"
+checksum = "ea259e8f54c31d8088fea71fa315456b6cedaa5851ec3fafbe9daca49c6884f6"
 dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -3140,16 +3249,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "syn 1.0.60",
  "synstructure",
 ]
 
 [[package]]
 name = "zip"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2896475a242c41366941faa27264df2cb935185a92e059a004d0048feb2ac5"
+checksum = "8264fcea9b7a036a4a5103d7153e988dbc2ebbafb34f68a3c2d404b6b82d74b6"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,10 @@ serde_json = "1.0.53"
 structopt = "~0.3.17"
 crdts = "4.3.0"
 ed25519-dalek = "1.0.1"
-sn_routing = { git = "https://github.com/bochaco/sn_routing.git", branch = "upgrade-tokio" }
-#sn_routing = "~0.46.0"
-sn_transfers = "~0.4.0"
-sn_messaging = "~6.0.0"
-sn_data_types = "~0.15.0"
+sn_routing = "~0.49.0"
+sn_transfers = "~0.5.0"
+sn_messaging = "~8.0.0"
+sn_data_types = "~0.16.0"
 ed25519 = "1.0.1"
 signature = "1.1.10"
 xor_name = "1.1.10"
@@ -76,16 +75,13 @@ async-trait = "0.1.42"
 
   [dependencies.tokio]
   version = "1.2.0"
-  features = [ "macros", "fs", "sync", "io-util" ]
+  features = [ "macros", "fs", "sync", "io-util", "rt", "rt-multi-thread" ]
 
 [dev_dependencies]
 maplit = "1.0.1"
 tempdir = "~0.3.7"
 futures = "~0.3.8"
 
-  [dev_dependencies.tokio]
-  version = "1.2.0"
-  features = [ "rt", "rt-multi-thread" ]
 
 [[bin]]
 name = "sn_node"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.28.2"
 development = [ "sn_client", "maplit" ]
 
 [dependencies]
+anyhow="1.0.36"
 async-log = "2.0.0"
 base64 = "~0.10.1"
 bincode = "1.2.1"
@@ -31,8 +32,9 @@ rand_chacha = "~0.2.2"
 serde_json = "1.0.53"
 structopt = "~0.3.17"
 crdts = "4.3.0"
-ed25519-dalek = "1.0.0-pre.4"
-sn_routing = "~0.46.0"
+ed25519-dalek = "1.0.1"
+sn_routing = { git = "https://github.com/bochaco/sn_routing.git", branch = "upgrade-tokio" }
+#sn_routing = "~0.46.0"
 sn_transfers = "~0.4.0"
 sn_messaging = "~6.0.0"
 sn_data_types = "~0.15.0"
@@ -73,17 +75,17 @@ async-trait = "0.1.42"
   version = "~0.4.0"
 
   [dependencies.tokio]
-  version = "~0.2.5"
-  features = [ "macros", "fs", "sync" ]
+  version = "1.2.0"
+  features = [ "macros", "fs", "sync", "io-util" ]
 
 [dev_dependencies]
 maplit = "1.0.1"
 tempdir = "~0.3.7"
-futures = "~0.3.5"
+futures = "~0.3.8"
 
   [dev_dependencies.tokio]
-  version = "~0.2.21"
-  features = [ "rt-core", "blocking", "stream", "rt-util", "rt-threaded" ]
+  version = "1.2.0"
+  features = [ "rt", "rt-multi-thread" ]
 
 [[bin]]
 name = "sn_node"

--- a/src/bin/launch_network.rs
+++ b/src/bin/launch_network.rs
@@ -35,7 +35,7 @@ use std::{
     path::PathBuf,
     process::{Command, Stdio},
 };
-use tokio::time::{delay_for, Duration};
+use tokio::time::{sleep, Duration};
 
 #[cfg(not(target_os = "windows"))]
 const SAFE_NODE_EXECUTABLE: &str = "sn_node";
@@ -142,7 +142,7 @@ pub async fn run_network() -> Result<(), String> {
 
     let mut verbosity_arg = String::from("-");
     if verbosity > 0 {
-        let v = "y".repeat(verbosity as usize);
+        let v = "y".repeat(verbosity);
         info!("V: {}", v);
         verbosity_arg.push_str(&v);
         sn_launch_tool_args.push(&verbosity_arg);
@@ -159,7 +159,7 @@ pub async fn run_network() -> Result<(), String> {
 
     let interval_duration = Duration::from_secs(interval_as_int * 15);
 
-    delay_for(interval_duration).await;
+    sleep(interval_duration).await;
 
     Ok(())
 }

--- a/src/bin/sn_node.rs
+++ b/src/bin/sn_node.rs
@@ -39,7 +39,7 @@ fn main() {
         .name("sn_node".to_string())
         .stack_size(8 * 1024 * 1024)
         .spawn(move || {
-            let mut rt = tokio::runtime::Runtime::new()?;
+            let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(run_node());
             Ok::<(), std::io::Error>(())
         });

--- a/src/capacity/rate_limit.rs
+++ b/src/capacity/rate_limit.rs
@@ -201,7 +201,7 @@ mod test {
     }
 
     #[test]
-    fn rate_limit_is_applied_up_to_3400_billion_nodes() {
+    fn rate_limit_is_applied_up_to_3300_billion_nodes() {
         // setup
         // The size of the actual DataCmd
         // is used for storecost calc,
@@ -211,7 +211,7 @@ mod test {
         let minimum_storage_bytes = mem::size_of::<DataCmd>() as u64;
         let half_full_nodes = 99;
         let big_section_node_count = 199;
-        let big_prefix_len = 34;
+        let big_prefix_len = 33;
         // storage rate limit is applied up to 3400 billion nodes
         let endcost = RateLimit::rate_limit(
             minimum_storage_bytes,

--- a/src/chunk_store/used_space.rs
+++ b/src/chunk_store/used_space.rs
@@ -9,7 +9,7 @@
 use crate::{Error, Result};
 use log::warn;
 use std::{path::Path, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::{io::AsyncSeekExt, sync::Mutex};
 
 const USED_SPACE_FILENAME: &str = "used_space";
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -12,10 +12,10 @@ use ed25519_dalek::PublicKey as Ed25519PublicKey;
 use futures::lock::Mutex;
 use serde::Serialize;
 use sn_data_types::{PublicKey, Signature};
-use sn_messaging::{DstLocation, SrcLocation};
+use sn_messaging::Itinerary;
 use sn_routing::{
     Config as RoutingConfig, Error as RoutingError, EventStream, Routing as RoutingNode,
-    SectionProofChain,
+    SectionChain,
 };
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
@@ -119,14 +119,13 @@ impl Network {
 
     pub async fn send_message(
         &mut self,
-        src: SrcLocation,
-        dst: DstLocation,
+        itinerary: Itinerary,
         content: Bytes,
     ) -> Result<(), RoutingError> {
         self.routing
             .lock()
             .await
-            .send_message(src, dst, content)
+            .send_message(itinerary, content)
             .await
     }
 
@@ -139,7 +138,7 @@ impl Network {
             .map_err(Error::Routing)
     }
 
-    pub async fn our_history(&self) -> SectionProofChain {
+    pub async fn our_history(&self) -> SectionChain {
         self.routing.lock().await.our_history().await
     }
 

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use sn_data_types::{PublicKey, Signature, SignatureShare};
 use sn_messaging::client::TransientElderKey;
-use sn_routing::SectionProofChain;
+use sn_routing::SectionChain;
 use std::{
     collections::BTreeSet,
     net::SocketAddr,
@@ -72,7 +72,7 @@ pub struct AdultState {
     prefix: Prefix,
     node_name: XorName,
     node_id: Ed25519PublicKey,
-    section_proof_chain: SectionProofChain,
+    section_proof_chain: SectionChain,
     elders: Vec<(XorName, SocketAddr)>,
     adult_reader: AdultReader,
     node_signing: NodeSigning,
@@ -109,7 +109,7 @@ impl AdultState {
     }
 
     /// Static state
-    pub fn section_proof_chain(&self) -> &SectionProofChain {
+    pub fn section_proof_chain(&self) -> &SectionChain {
         &self.section_proof_chain
     }
 
@@ -128,7 +128,7 @@ pub struct ElderState {
     node_id: Ed25519PublicKey,
     key_index: usize,
     public_key_set: PublicKeySet,
-    section_proof_chain: SectionProofChain,
+    section_proof_chain: SectionChain,
     elders: Vec<(XorName, SocketAddr)>,
     adult_reader: AdultReader,
     interaction: NodeInteraction,
@@ -215,7 +215,7 @@ impl ElderState {
     }
 
     /// Static state
-    pub fn section_proof_chain(&self) -> &SectionProofChain {
+    pub fn section_proof_chain(&self) -> &SectionChain {
         &self.section_proof_chain
     }
 

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -22,7 +22,7 @@ use sn_messaging::{
         CmdError, Error as ErrorMessage, Message, NodeDataQueryResponse, NodeQuery,
         NodeQueryResponse, NodeSystemQuery, QueryResponse,
     },
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use std::{
     collections::BTreeSet,
@@ -61,7 +61,7 @@ impl ChunkStorage {
                     target_section_pk: None,
                 },
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }))
         } else {
             Ok(NodeMessagingDuty::NoOp)
@@ -113,7 +113,7 @@ impl ChunkStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -163,7 +163,7 @@ impl ChunkStorage {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -229,7 +229,7 @@ impl ChunkStorage {
                     target_section_pk: None,
                 },
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }));
         }
         Ok(NodeMessagingDuty::NoOp)

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -20,7 +20,7 @@ use sn_messaging::{
         BlobRead, BlobWrite, CmdError, Error as ErrorMessage, Message, NodeCmd, NodeQuery,
         NodeSystemCmd, QueryResponse,
     },
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 
 use std::{
@@ -90,7 +90,7 @@ impl BlobRegister {
                             target_section_pk: None,
                         },
                         dst: DstLocation::EndUser(origin),
-                        to_be_aggregated: false,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     }));
                 }
             } else {
@@ -159,7 +159,7 @@ impl BlobRegister {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -348,7 +348,7 @@ impl BlobRegister {
                 NodeMessagingDuty::Send(OutgoingMsg {
                     msg,
                     dst: DstLocation::Node(dst),
-                    to_be_aggregated: false,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 })
                 .into(),
             );
@@ -386,7 +386,7 @@ impl BlobRegister {
             Ok(NodeMessagingDuty::Send(OutgoingMsg {
                 msg: err_msg,
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }))
         };
 

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -20,7 +20,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{CmdError, MapRead, MapWrite, Message, QueryResponse},
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 
 use std::fmt::{self, Display, Formatter};
@@ -233,7 +233,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -261,7 +261,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -289,7 +289,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -327,7 +327,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -355,7 +355,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -384,7 +384,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -413,7 +413,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -441,7 +441,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -473,7 +473,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -496,7 +496,7 @@ impl MapStorage {
                     target_section_pk: None,
                 },
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true, // this needs more consideration...
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,  // this needs more consideration...
             }))
         } else {
             info!("MapStorage: Writing chunk PASSED!");

--- a/src/node/elder_duties/data_section/metadata/sequence_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/sequence_storage.rs
@@ -20,7 +20,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{CmdError, Message, QueryResponse, SequenceRead, SequenceWrite},
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 
 use std::fmt::{self, Display, Formatter};
@@ -109,7 +109,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -181,7 +181,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -209,7 +209,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -242,7 +242,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -272,7 +272,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -305,7 +305,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -338,7 +338,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -408,7 +408,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(origin.name()),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 }

--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -27,7 +27,7 @@ use sn_messaging::{
         Error as ErrorMessage, Message, NodeQuery, NodeQueryResponse, NodeRewardQuery,
         NodeRewardQueryResponse,
     },
-    DstLocation, MessageId, SrcLocation,
+    Aggregation, DstLocation, MessageId, SrcLocation,
 };
 
 use sn_transfers::TransferActor;
@@ -101,7 +101,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(section),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })
         .into())
     }
@@ -248,7 +248,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })
     }
 
@@ -314,7 +314,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(old_node_id),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -439,7 +439,7 @@ impl Rewards {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }));
             }
         };
@@ -462,7 +462,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(new_node_id),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 }

--- a/src/node/elder_duties/data_section/rewards/section_funds.rs
+++ b/src/node/elder_duties/data_section/rewards/section_funds.rs
@@ -21,7 +21,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{Message, NodeCmd, NodeQuery, NodeTransferCmd, NodeTransferQuery},
-    DstLocation, MessageId,
+    Aggregation, DstLocation, MessageId,
 };
 use sn_transfers::{ActorEvent, TransferActor};
 use std::collections::{BTreeSet, VecDeque};
@@ -121,7 +121,7 @@ impl SectionFunds {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(new_wallet.into()),
-            to_be_aggregated: false, // TODO aggregate this
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -194,7 +194,7 @@ impl SectionFunds {
                             target_section_pk: None,
                         },
                         dst: DstLocation::Section(self.actor.id().into()),
-                        to_be_aggregated: false,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     }))
                 }
             }
@@ -242,7 +242,7 @@ impl SectionFunds {
                         target_section_pk: None,
                     },
                     dst: DstLocation::Section(self.actor.id().into()),
-                    to_be_aggregated: false,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -294,7 +294,7 @@ impl SectionFunds {
                     target_section_pk: None,
                 },
                 dst: DstLocation::Section(self.actor.id().into()),
-                to_be_aggregated: false, // TODO: aggregate here (not needed, but makes sn_node logs less chatty..)
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination, // TODO: aggregate here (not needed, but makes sn_node logs less chatty..)
             }));
 
             // First register the transfer, then

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -28,7 +28,7 @@ where
     id: bls::PublicKeyShare,
     key_index: usize,
     peer_replicas: bls::PublicKeySet,
-    section_proof_chain: sn_routing::SectionProofChain,
+    section_proof_chain: sn_routing::SectionChain,
     signing: T,
     initiating: bool,
 }

--- a/src/node/elder_duties/key_section/transfers/mod.rs
+++ b/src/node/elder_duties/key_section/transfers/mod.rs
@@ -38,7 +38,7 @@ use sn_messaging::{
         NodeQuery, NodeQueryResponse, NodeTransferCmd, NodeTransferError, NodeTransferQuery,
         NodeTransferQueryResponse, QueryResponse, TransferError,
     },
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use std::fmt::{self, Display, Formatter};
 use xor_name::Prefix;
@@ -105,7 +105,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(pub_key.into()),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })))
     }
 
@@ -278,7 +278,7 @@ impl Transfers {
                     target_section_pk: None,
                 },
                 dst: origin.to_dst(),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }));
         }
         let registration = self.replicas.register(&payment).await;
@@ -322,7 +322,7 @@ impl Transfers {
                             target_section_pk: None,
                         },
                         dst: origin.to_dst(),
-                        to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     }));
                 }
                 info!("Payment: forwarding data..");
@@ -338,7 +338,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: DstLocation::Section(dst_address),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
             Err(e) => {
@@ -355,7 +355,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -387,7 +387,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: query_origin.to_dst(),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -413,7 +413,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -435,7 +435,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -462,7 +462,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -496,7 +496,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // this has to be sorted out by recipient..
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination, // this has to be sorted out by recipient..
         }))
     }
 
@@ -524,7 +524,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // this has to be sorted out by recipient..
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination, // this has to be sorted out by recipient..
         }))
     }
 
@@ -547,7 +547,7 @@ impl Transfers {
                     target_section_pk: None,
                 },
                 dst: origin.to_dst(),
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })),
             Err(e) => {
                 let message_error = convert_to_error_message(e)?;
@@ -560,7 +560,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -585,7 +585,7 @@ impl Transfers {
                     target_section_pk: None,
                 },
                 dst: origin.to_dst(),
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })),
             Err(e) => {
                 let message_error = convert_to_error_message(e)?;
@@ -600,7 +600,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -626,7 +626,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: DstLocation::Section(location),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true, // not necessary, but will be slimmer
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,  // not necessary, but will be slimmer
                 }))
             }
             Err(e) => {
@@ -642,7 +642,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: DstLocation::EndUser(EndUser::AllClients(proof.sender())),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -676,7 +676,7 @@ impl Transfers {
                             target_section_pk: None,
                         },
                         dst: DstLocation::Section(location),
-                        to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     })
                     .into(),
                 );
@@ -690,7 +690,7 @@ impl Transfers {
                             target_section_pk: None,
                         },
                         dst: DstLocation::Section(location),
-                        to_be_aggregated: false, // TODO: to_be_aggregated: true, // not necessary, but will be slimmer
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,  // not necessary, but will be slimmer
                     })
                     .into(),
                 );
@@ -709,7 +709,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 })))
             }
         }
@@ -744,7 +744,7 @@ impl Transfers {
         Ok(NodeMessagingDuty::Send(OutgoingMsg {
             msg,
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 

--- a/src/node/elder_duties/key_section/transfers/replicas.rs
+++ b/src/node/elder_duties/key_section/transfers/replicas.rs
@@ -582,7 +582,7 @@ mod test {
     use bls::{PublicKeySet, SecretKeySet};
     use futures::executor::block_on as run;
     use sn_data_types::{Keypair, OwnerType, PublicKey, SignedTransferShare, Token};
-    use sn_routing::SectionProofChain;
+    use sn_routing::SectionChain;
     use sn_transfers::{ActorEvent, TransferActor as Actor, Wallet};
     use tempdir::TempDir;
 
@@ -737,7 +737,7 @@ mod test {
             id,
             key_index,
             peer_replicas: peer_replicas.clone(),
-            section_proof_chain: SectionProofChain::new(peer_replicas.public_key()),
+            section_proof_chain: SectionChain::new(peer_replicas.public_key()),
             signing,
             initiating: true,
         };

--- a/src/node/node_duties/messaging.rs
+++ b/src/node/node_duties/messaging.rs
@@ -41,12 +41,15 @@ impl Messaging {
     }
 
     async fn send(&mut self, msg: OutgoingMsg) -> Result<NetworkDuties> {
-        let itry = Itinerary {
+        let itinerary = Itinerary {
             src: SrcLocation::Node(self.network.our_name().await),
             dst: msg.dst,
             aggregation: msg.aggregation,
         };
-        let result = self.network.send_message(itry, msg.msg.serialize()?).await;
+        let result = self
+            .network
+            .send_message(itinerary, msg.msg.serialize()?)
+            .await;
 
         result.map_or_else(
             |err| {

--- a/src/node/node_duties/messaging.rs
+++ b/src/node/node_duties/messaging.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use crate::{Network, Result};
 use log::error;
-use sn_messaging::{client::Message, DstLocation, SrcLocation};
+use sn_messaging::{client::Message, Aggregation, DstLocation, Itinerary, SrcLocation};
 use sn_routing::XorName;
 
 /// Sending of messages
@@ -41,14 +41,24 @@ impl Messaging {
     }
 
     async fn send(&mut self, msg: OutgoingMsg) -> Result<NetworkDuties> {
-        let src = if msg.to_be_aggregated {
-            SrcLocation::Section(self.network.our_prefix().await)
+        let itinerary = if msg.to_be_aggregated {
+            let src = SrcLocation::Section(self.network.our_name().await);
+            Itinerary {
+                src,
+                dst: msg.dst,
+                aggregation: Aggregation::AtSource,
+            }
         } else {
-            SrcLocation::Node(self.network.our_name().await)
+            let src = SrcLocation::Node(self.network.our_name().await);
+            Itinerary {
+                src,
+                dst: msg.dst,
+                aggregation: Aggregation::None,
+            }
         };
         let result = self
             .network
-            .send_message(src, msg.dst, msg.msg.serialize()?)
+            .send_message(itinerary, msg.msg.serialize()?)
             .await;
 
         result.map_or_else(
@@ -68,12 +78,13 @@ impl Messaging {
         let name = self.network.our_name().await;
         let bytes = &msg.serialize()?;
         for target in targets {
+            let itinerary = Itinerary {
+                src: SrcLocation::Node(name),
+                dst: DstLocation::Node(XorName(target.0)),
+                aggregation: Aggregation::AtDestination,
+            };
             self.network
-                .send_message(
-                    SrcLocation::Node(name),
-                    DstLocation::AccumulatingNode(XorName(target.0)),
-                    bytes.clone(),
-                )
+                .send_message(itinerary, bytes.clone())
                 .await
                 .map_or_else(
                     |err| {

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -33,7 +33,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{Message, NodeCmd, NodeQuery, NodeRewardQuery, NodeSystemCmd},
-    DstLocation, MessageId, SrcLocation,
+    Aggregation, DstLocation, MessageId, SrcLocation,
 };
 use std::collections::{BTreeMap, VecDeque};
 
@@ -257,7 +257,7 @@ impl NodeDuties {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(node_id.into()),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })))
     }
 
@@ -274,7 +274,7 @@ impl NodeDuties {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(wallet.into()),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })))
     }
 
@@ -352,7 +352,7 @@ impl NodeDuties {
                     target_section_pk: None,
                 },
                 dst,
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })));
         } else if is_genesis_section && elder_count < GENESIS_ELDER_COUNT {
             debug!("AwaitingGenesisThreshold!");
@@ -374,7 +374,7 @@ impl NodeDuties {
                     target_section_pk: None,
                 },
                 dst: DstLocation::Section(wallet_id.into()),
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })));
         }
 
@@ -421,7 +421,7 @@ impl NodeDuties {
                         target_section_pk: None,
                     },
                     dst,
-                    to_be_aggregated: false,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 });
 
                 (stage, cmd)
@@ -457,7 +457,7 @@ impl NodeDuties {
                         dst: DstLocation::Section(
                             bootstrap.elder_state.section_public_key().into(),
                         ),
-                        to_be_aggregated: false,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     });
 
                     (stage, cmd)

--- a/src/node/node_duties/msg_analysis.rs
+++ b/src/node/node_duties/msg_analysis.rs
@@ -79,14 +79,6 @@ impl ReceivedMsgAnalysis {
                     Ok(res)
                 }
             }
-            DstLocation::AccumulatingNode(_name) => {
-                let res = self.match_node_msg(msg.clone(), src)?;
-                if res.is_empty() {
-                    self.match_section_msg(msg, src)
-                } else {
-                    Ok(res)
-                }
-            }
             _ => Err(Error::InvalidMessage(
                 msg_id,
                 format!("Invalid dst: {:?}", msg),

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -14,7 +14,7 @@ use sn_data_types::{
     SignedCredit, SignedTransfer, SignedTransferShare, TransferAgreementProof, TransferValidated,
     WalletInfo,
 };
-use sn_messaging::{client::Message, DstLocation, EndUser, MessageId, SrcLocation};
+use sn_messaging::{client::Message, Aggregation, DstLocation, EndUser, MessageId, SrcLocation};
 use std::fmt::Formatter;
 
 use sn_routing::{Event as RoutingEvent, Prefix};
@@ -147,7 +147,7 @@ impl Debug for NodeDuty {
 pub struct OutgoingMsg {
     pub msg: Message,
     pub dst: DstLocation,
-    pub to_be_aggregated: bool,
+    pub aggregation: Aggregation,
 }
 
 impl OutgoingMsg {


### PR DESCRIPTION
This PR updates to the newer versions of sn_data_types, sn_transfers, sn_messaging, sn_routing, qp2p and tokio.

This includes changes from #1313 #1315 #1317 and #1196 