### PR TITLE
fix(rewards): sync wallets in a better way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-log",

--- a/src/bin/sn_node.rs
+++ b/src/bin/sn_node.rs
@@ -86,8 +86,6 @@ async fn run_node() {
 
     utils::init_logging(&config);
 
-    info!("Node PID is: {:?}", std::process::id());
-
     if config.update() || config.update_only() {
         match update() {
             Ok(status) => {
@@ -119,17 +117,18 @@ async fn run_node() {
             process::exit(1);
         }
     };
-
+    let node_name = node.our_name().await;
     let our_conn_info = node.our_connection_info().await;
+    let our_pid = std::process::id();
+    let our_conn_info_json = serde_json::to_string(&our_conn_info)
+        .unwrap_or_else(|_| "Failed to serialize connection info".into());
     println!(
-        "Node connection info:\n{}",
-        serde_json::to_string(&our_conn_info)
-            .unwrap_or_else(|_| "Failed to serialize connection info".into())
+        "Node PID: {:?}, name: {}, connection info:\n{}",
+        our_pid, node_name, our_conn_info_json,
     );
     info!(
-        "Node connection info: {}",
-        serde_json::to_string(&our_conn_info)
-            .unwrap_or_else(|_| "Failed to serialize connection info".into())
+        "Node PID: {:?}, name: {}, connection info: {}",
+        our_pid, node_name, our_conn_info_json,
     );
 
     if config.is_first() {

--- a/src/metadata/blob_register.rs
+++ b/src/metadata/blob_register.rs
@@ -310,8 +310,6 @@ impl BlobRegister {
     }
 
     pub(super) async fn replicate_chunks(&mut self, holder: XorName) -> Result<NodeDuties> {
-        trace!("Replicating chunks of holder {:?}", holder);
-
         let chunks_stored = match self.remove_holder(holder).await {
             Ok(chunks) => chunks,
             _ => return Ok(vec![]),

--- a/src/network.rs
+++ b/src/network.rs
@@ -147,6 +147,10 @@ impl Network {
         self.routing.name().await
     }
 
+    pub async fn our_age(&self) -> u8 {
+        self.routing.age().await
+    }
+
     pub async fn our_connection_info(&mut self) -> SocketAddr {
         self.routing.our_connection_info()
     }

--- a/src/node/member_churn.rs
+++ b/src/node/member_churn.rs
@@ -103,8 +103,8 @@ impl Node {
         let no_wallet_found = node_wallets.get(&node_id).is_none();
         if no_wallet_found {
             info!(
-                "Registering wallet of node: {} (since not found in {:?})",
-                node_id, node_wallets
+                "Registering wallet of node: {} (since not found in received state)",
+                node_id,
             );
             Ok(NodeDuty::Send(self.register_wallet().await))
         } else {

--- a/src/node/messaging.rs
+++ b/src/node/messaging.rs
@@ -14,9 +14,10 @@ use sn_routing::XorName;
 use std::collections::BTreeSet;
 
 pub(crate) async fn send(msg: OutgoingMsg, network: &Network) -> Result<()> {
-    trace!("Sending msg: {:?}", msg);
+    let our_prefix = network.our_prefix().await;
+    trace!("{:?}, Sending msg: {:?}", our_prefix, msg);
     let src = if msg.section_source {
-        SrcLocation::Section(network.our_prefix().await.name())
+        SrcLocation::Section(our_prefix.name())
     } else {
         SrcLocation::Node(network.our_name().await)
     };
@@ -41,7 +42,13 @@ pub(crate) async fn send_to_nodes(
     msg: &Message,
     network: &Network,
 ) -> Result<()> {
-    trace!("Sending msg to nodes: {:?}: {:?}", targets, msg);
+    let our_prefix = network.our_prefix().await;
+    trace!(
+        "{:?}, Sending msg to nodes: {:?}: {:?}",
+        our_prefix,
+        targets,
+        msg
+    );
 
     let name = network.our_name().await;
     let bytes = &msg.serialize()?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -122,7 +122,7 @@ impl Node {
 
         let used_space = UsedSpace::new(config.max_capacity());
 
-        let mut node = Self {
+        let node = Self {
             prefix: network_api.our_prefix().await,
             chunks: Some(
                 Chunks::new(
@@ -141,11 +141,6 @@ impl Node {
             section_funds: None,
         };
 
-        // was not necessary when AE changes were in
-        if config.is_first() {
-            node.level_up().await?;
-        }
-
         messaging::send(node.register_wallet().await, &node.network_api).await;
 
         Ok(node)
@@ -154,6 +149,11 @@ impl Node {
     /// Returns our connection info.
     pub async fn our_connection_info(&mut self) -> SocketAddr {
         self.network_api.our_connection_info().await
+    }
+
+    /// Returns our name.
+    pub async fn our_name(&mut self) -> XorName {
+        self.network_api.our_name().await
     }
 
     /// Starts the node, and runs the main event loop.

--- a/src/node_ops.rs
+++ b/src/node_ops.rs
@@ -125,7 +125,8 @@ pub enum NodeDuty {
     ReceiveRewardProposal(RewardProposal),
     /// Accumulation of payout of rewards.
     ReceiveRewardAccumulation(RewardAccumulation),
-    ChurnMembers {
+    Genesis,
+    EldersChanged {
         /// Our section prefix.
         our_prefix: Prefix,
         /// our section public key
@@ -133,7 +134,7 @@ pub enum NodeDuty {
         /// oldie or newbie?
         newbie: bool,
     },
-    SplitSection {
+    SectionSplit {
         /// Our section prefix.
         our_prefix: Prefix,
         /// our section public key
@@ -229,6 +230,7 @@ impl From<NodeDuty> for NodeDuties {
 impl Debug for NodeDuty {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Genesis { .. } => write!(f, "Genesis"),
             Self::AddPayment { .. } => write!(f, "AddPayment"),
             Self::GetNodeWalletKey { .. } => write!(f, "GetNodeWalletKey"),
             Self::PropagateTransfer { .. } => write!(f, "PropagateTransfer"),
@@ -247,8 +249,8 @@ impl Debug for NodeDuty {
             // ------
             Self::LevelDown => write!(f, "LevelDown"),
             Self::SynchState { .. } => write!(f, "SynchState"),
-            Self::ChurnMembers { .. } => write!(f, "ChurnMembers"),
-            Self::SplitSection { .. } => write!(f, "SplitSection"),
+            Self::EldersChanged { .. } => write!(f, "EldersChanged"),
+            Self::SectionSplit { .. } => write!(f, "SectionSplit"),
             Self::GetSectionElders { .. } => write!(f, "GetSectionElders"),
 
             Self::NoOp => write!(f, "No op."),

--- a/src/section_funds/mod.rs
+++ b/src/section_funds/mod.rs
@@ -80,7 +80,7 @@ impl SectionFunds {
 
     /// When the section becomes aware that a node has left,
     /// its reward key is removed.
-    pub fn remove_node_wallet(&self, node_name: XorName) -> Result<()> {
+    pub fn remove_node_wallet(&self, node_name: XorName) {
         match &self {
             Self::Churning { wallets, .. } | Self::KeepingNodeWallets { wallets, .. } => {
                 wallets.remove_wallet(node_name)

--- a/src/section_funds/reward_calc.rs
+++ b/src/section_funds/reward_calc.rs
@@ -16,7 +16,7 @@ const MIN_REWARD_AGE: u8 = 5;
 ///  -----  MINTING  -----
 /// This is the minting of new coins happening;
 /// the size being the sum of payments to parent section,
-/// i.e. it at least doubles the amount paid into section,
+/// i.e. it at most doubles the amount paid into section,
 /// or else what's left until we've reached max supply.
 /// Max supply is the proportional supply for a section in
 /// a network of a certain size, i.e. max _total_ supply (2^32) divided by number of sections.
@@ -41,7 +41,7 @@ pub fn get_reward_and_mint_amount(
         if payments > excess_supply {
             payments - excess_supply
         } else {
-            0 // can't go minus rewards, but whatever was paid has been burned completely
+            0 // can't go minus rewards, but whatever was paid is now burned completely
         }
     };
 

--- a/src/section_funds/reward_wallets.rs
+++ b/src/section_funds/reward_wallets.rs
@@ -76,9 +76,7 @@ impl RewardWallets {
 
     /// When the section becomes aware that a node has left,
     /// its reward key is removed.
-    pub fn remove_wallet(&self, node_name: XorName) -> Result<()> {
-        debug!("Rewards: removing {}", node_name);
+    pub fn remove_wallet(&self, node_name: XorName) {
         let _ = self.node_rewards.remove(&node_name);
-        Ok(())
     }
 }


### PR DESCRIPTION
- Only push state belonging to dst.
- Many node wallets were not synced. Bit of sledgehammer now, but syncs a bit better..
- Also removes empty runs of rewarding.