### PR TITLE
Deduplicate options in non idg case

### DIFF
--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -156,8 +156,13 @@ impl Config {
         }
 
         if self.public_addr.is_none() && self.local_addr.is_some() {
-            println!("Warning: Local Address provided is skipped since external address is not provided.");
-            self.local_addr = None;
+            if self.skip_igd {
+                // local_addr duplicated to public_addr so that the specified port is used (and not a random one)
+                self.public_addr = self.local_addr;
+            } else {
+                println!("Warning: Local Address provided is skipped since external address is not provided.");
+                self.local_addr = None;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
In standard case (non IGD) we need to pass both `--public-addr` and `--local-addr` options to be able to control the port number used by the node.

`--public-addr` can be omitted, but then the port number specified by `--local-addr` is not taken into account (a random one is used instead), which is the same as omitting both options:

```plain
~ # sn_node -m 2000000000 --local-addr 172.20.0.4:5483 --skip-igd --clear-data -h '["172.20.0.3:5483"]' -vvvv > v.log 2>&1 &
~ #
~ # netstat -lunp | grep sn_node
udp        0      0 172.20.0.4:35743        0.0.0.0:*                           60/sn_node
```

`--local-addr` cannot be omitted, otherwise we get `Failed to create Config: Configuration("--public-addr passed without specifing local address using --first or --local-addr")`.

The need to pass twice the same socket address to be able to control the port number is a regression compared to earlier `--ip/--port` parameters. Of course now you can use IGD but there is no reason that the usage becomes more complex when we don't use it.

I have issued a PR to correct this by automatically duplicating `--local-addr` to `--public-addr` when the 3 following conditions are met:
- `--local-addr` is specified
- `--skip-igd` is specified
- `--public-addr` is not specified

I have proposed this in sn_node to not destabilize qp2p, and it's only a small test to add in sn_node.