### PR TITLE
Split Node state between Adult/Elder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "sn_routing"
-version = "0.59.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f5272314916e8e793a1dcd978a70aaa5b7a5b6c2c558d94c51172fd9bb37cb"
+checksum = "2b913d4ed93c4265fa0c1adbe5f190680317947e9eb0c6d162251c0387416810"
 dependencies = [
  "bincode",
  "bls_dkg",

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,12 @@ use xor_name::XorName;
 #[non_exhaustive]
 /// Node error variants.
 pub enum Error {
+    /// Attempted to perform an operation meant only for Adults when we are not one.
+    #[error("Attempted Adult operation when not an Adult")]
+    NotAnAdult,
+    /// Attempted to perform an operation meant only for Elders when we are not one.
+    #[error("Attempted Elder operation when not an Elder")]
+    NotAnElder,
     /// The key balance already exists when it was expected to be empty (during section genesis)
     #[error("Balance already exists.")]
     BalanceExists,

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,21 +62,6 @@ pub enum Error {
     /// Key, Value pair not found in `ChunkStore`.
     #[error("No such chunk")]
     NoSuchChunk,
-    /// This node does not know or manage any chunks
-    #[error("No chunks")]
-    NoChunks,
-    /// This node does not know or manage any metadata
-    #[error("No metadata")]
-    NoMetadata,
-    /// This node does not know or manage any transfers
-    #[error("No transfers")]
-    NoTransfers,
-    /// This node does not know or manage any section funds
-    #[error("No section funds")]
-    NoSectionFunds,
-    /// Unable to process fund churn message.
-    #[error("Cannot process fund churn message")]
-    NotChurningFunds,
     /// Creating temp directory failed.
     #[error("Could not create temp store: {0}")]
     TempDirCreationFailed(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,9 @@ pub enum Error {
     /// Key, Value pair not found in `ChunkStore`.
     #[error("No such chunk")]
     NoSuchChunk,
+    /// Unable to process fund churn message.
+    #[error("Cannot process fund churn message")]
+    NotChurningFunds,
     /// Creating temp directory failed.
     #[error("Could not create temp store: {0}")]
     TempDirCreationFailed(String),

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -238,10 +238,8 @@ impl Node {
                 msg_id,
                 origin,
             } => {
-                let elder = self.role.as_elder()?;
-                Ok(vec![
-                    elder.transfers.get_store_cost(bytes, msg_id, origin).await,
-                ])
+                let elder = self.role.as_elder_mut()?;
+                Ok(elder.transfers.get_store_cost(bytes, msg_id, origin).await)
             }
             NodeDuty::RegisterTransfer { proof, msg_id } => {
                 let elder = self.role.as_elder_mut()?;

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -84,8 +84,7 @@ impl Node {
                     info!("Handling Churn proposal as an Elder");
                     Ok(vec![process.receive_churn_proposal(proposal).await?])
                 } else {
-                    // we are not churning, so ignore this msg
-                    Ok(vec![])
+                    Err(Error::NotChurningFunds)
                 }
             }
             NodeDuty::ReceiveRewardAccumulation(accumulation) => {

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -115,8 +115,7 @@ impl Node {
 
                     Ok(ops)
                 } else {
-                    // else we are not churning so ignore this message
-                    Ok(vec![])
+                    Err(Error::NotChurningFunds)
                 }
             }
             //

--- a/src/node/interaction.rs
+++ b/src/node/interaction.rs
@@ -128,14 +128,14 @@ impl Node {
     pub fn push_state(&self, prefix: Prefix, msg_id: MessageId) -> NodeDuty {
         let dst = DstLocation::Section(prefix.name());
 
-        let user_wallets = if let Some(elder_state) = &self.elder_state {
-            elder_state.transfers.user_wallets()
+        let user_wallets = if let Ok(elder) = &self.role.as_elder() {
+            elder.transfers.user_wallets()
         } else {
             BTreeMap::new()
         };
 
-        let node_rewards = if let Some(elder_state) = &self.elder_state {
-            match &elder_state.section_funds {
+        let node_rewards = if let Ok(elder) = &self.role.as_elder() {
+            match &elder.section_funds {
                 SectionFunds::KeepingNodeWallets { wallets, .. }
                 | SectionFunds::Churning { wallets, .. } => wallets.node_wallets(),
             }

--- a/src/node/interaction.rs
+++ b/src/node/interaction.rs
@@ -135,10 +135,7 @@ impl Node {
         };
 
         let node_rewards = if let Ok(elder) = &self.role.as_elder() {
-            match &elder.section_funds {
-                SectionFunds::KeepingNodeWallets { wallets, .. }
-                | SectionFunds::Churning { wallets, .. } => wallets.node_wallets(),
-            }
+            elder.section_funds.node_wallets()
         } else {
             BTreeMap::new()
         };

--- a/src/node/interaction.rs
+++ b/src/node/interaction.rs
@@ -128,16 +128,19 @@ impl Node {
     pub fn push_state(&self, prefix: Prefix, msg_id: MessageId) -> NodeDuty {
         let dst = DstLocation::Section(prefix.name());
 
-        let user_wallets = if let Some(transfers) = &self.transfers {
-            transfers.user_wallets()
+        let user_wallets = if let Some(elder_state) = &self.elder_state {
+            elder_state.transfers.user_wallets()
         } else {
             BTreeMap::new()
         };
 
-        let node_rewards = match &self.section_funds {
-            Some(SectionFunds::KeepingNodeWallets { wallets, .. })
-            | Some(SectionFunds::Churning { wallets, .. }) => wallets.node_wallets(),
-            None => BTreeMap::new(),
+        let node_rewards = if let Some(elder_state) = &self.elder_state {
+            match &elder_state.section_funds {
+                SectionFunds::KeepingNodeWallets { wallets, .. }
+                | SectionFunds::Churning { wallets, .. } => wallets.node_wallets(),
+            }
+        } else {
+            BTreeMap::new()
         };
 
         // only push that what should be in dst

--- a/src/node/member_churn.rs
+++ b/src/node/member_churn.rs
@@ -89,13 +89,8 @@ impl Node {
         elder.transfers.merge(user_wallets);
 
         //  merge in provided node reward stages
-        match &mut elder.section_funds {
-            SectionFunds::KeepingNodeWallets { wallets, .. }
-            | SectionFunds::Churning { wallets, .. } => {
-                for (key, (age, wallet)) in &node_wallets {
-                    wallets.set_node_wallet(*key, *age, *wallet);
-                }
-            }
+        for (key, (age, wallet)) in &node_wallets {
+            elder.section_funds.set_node_wallet(*key, *wallet, *age)
         }
 
         let node_id = self.network_api.our_name().await;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -65,6 +65,20 @@ impl NodeInfo {
     }
 }
 
+struct AdultNode {
+    // immutable chunks
+    chunks: Chunks,
+}
+
+struct ElderNode {
+    // data operations
+    meta_data: Metadata,
+    // transfers
+    transfers: Transfers,
+    // reward payouts
+    section_funds: SectionFunds,
+}
+
 /// Main node struct.
 pub struct Node {
     network_api: Network,
@@ -72,14 +86,8 @@ pub struct Node {
     node_info: NodeInfo,
     used_space: UsedSpace,
     prefix: Prefix,
-    // immutable chunks
-    chunks: Option<Chunks>,
-    // data operations
-    meta_data: Option<Metadata>,
-    // transfers
-    transfers: Option<Transfers>,
-    // reward payouts
-    section_funds: Option<SectionFunds>,
+    adult_state: Option<AdultNode>,
+    elder_state: Option<ElderNode>,
 }
 
 impl Node {
@@ -124,21 +132,19 @@ impl Node {
 
         let node = Self {
             prefix: network_api.our_prefix().await,
-            chunks: Some(
-                Chunks::new(
+            adult_state: Some(AdultNode {
+                chunks: Chunks::new(
                     node_info.node_name,
                     node_info.root_dir.as_path(),
                     used_space.clone(),
                 )
                 .await?,
-            ),
+            }),
             node_info,
             used_space,
             network_api,
             network_events,
-            meta_data: None,
-            transfers: None,
-            section_funds: None,
+            elder_state: None,
         };
 
         messaging::send(node.register_wallet().await, &node.network_api).await;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -79,6 +79,7 @@ struct ElderRole {
     section_funds: SectionFunds,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum Role {
     Adult(AdultRole),
     Elder(ElderRole),

--- a/src/section_funds/mod.rs
+++ b/src/section_funds/mod.rs
@@ -14,7 +14,7 @@ pub mod reward_wallets;
 
 use self::{reward_process::RewardProcess, reward_wallets::RewardWallets};
 use super::node_ops::{NodeDuty, OutgoingMsg};
-use crate::Result;
+use crate::{Error, Result};
 use dashmap::DashMap;
 use log::info;
 use sn_data_types::{CreditAgreementProof, CreditId, NodeAge, PublicKey, SectionElders, Token};
@@ -41,6 +41,19 @@ pub enum SectionFunds {
 }
 
 impl SectionFunds {
+    pub fn as_churning_mut(
+        &mut self,
+    ) -> Result<(&mut RewardProcess, &mut RewardWallets, &mut Payments)> {
+        match self {
+            Self::Churning {
+                process,
+                wallets,
+                payments,
+            } => Ok((process, wallets, payments)),
+            _ => Err(Error::NotChurningFunds),
+        }
+    }
+
     /// Adds payment
     pub fn add_payment(&self, credit: CreditAgreementProof) {
         // todo: validate


### PR DESCRIPTION
The Node struct was using `Option`s over the fields that were only used when the node was behaving as an Elder vs. behaving as an Adult. This could lead us into inconsistent states where Adults who used to be Elders might still have some Elder state that was mistakenly not cleared (or vice-versa, Elder still behaving as Adult).

The node struct as it was prior to this PR:
```rust
/// Main node struct.
pub struct Node {
    network_api: Network,
    network_events: EventStream,
    node_info: NodeInfo,
    used_space: UsedSpace,
    prefix: Prefix,
    chunks: Option<Chunks>,  // <--- only used by Adults
    meta_data: Option<Metadata>, // <--- only used as Elder
    transfers: Option<Transfers>, // <--- only used as Elder
    section_funds: Option<SectionFunds>, // <--- only used as Elder
}
```
This is changed to the following:
```rust
pub struct Node {
    network_api: Network,
    network_events: EventStream,
    node_info: NodeInfo,
    used_space: UsedSpace,
    prefix: Prefix,
    role: Role, // <-- Role Enum
}
```
Where `Role` is defined as follows:
```rust
struct AdultRole {
    // immutable chunks
    chunks: Chunks,
}

struct ElderRole {
    // data operations
    meta_data: Metadata,
    // transfers
    transfers: Transfers,
    // reward payouts
    section_funds: SectionFunds,
}

enum Role {
    Adult(AdultRole),
    Elder(ElderRole),
}
```

The rest of this PR is just propagating this change throughout the codebase.