### PR TITLE
fix(msgs): add aggregation scheme to SendToNodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.36.0"
+version = "0.36.2"
 dependencies = [
  "anyhow",
  "async-log",

--- a/src/chunks/chunk_storage.rs
+++ b/src/chunks/chunk_storage.rs
@@ -138,6 +138,7 @@ impl ChunkStorage {
         Ok(NodeDuty::SendToNodes {
             msg,
             targets: current_holders,
+            aggregation: Aggregation::None,
         })
     }
 

--- a/src/metadata/blob_register.rs
+++ b/src/metadata/blob_register.rs
@@ -127,6 +127,7 @@ impl BlobRegister {
                 id: msg_id,
                 target_section_pk: None,
             },
+            aggregation: Aggregation::AtDestination,
         })
     }
 
@@ -190,8 +191,9 @@ impl BlobRegister {
             target_section_pk: None,
         };
         Ok(NodeDuty::SendToNodes {
-            targets: metadata.holders,
             msg,
+            targets: metadata.holders,
+            aggregation: Aggregation::AtDestination,
         })
     }
 
@@ -400,8 +402,9 @@ impl BlobRegister {
             target_section_pk: None,
         };
         Ok(NodeDuty::SendToNodes {
-            targets: metadata.holders,
             msg,
+            targets: metadata.holders,
+            aggregation: Aggregation::AtDestination,
         })
     }
 

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -304,8 +304,12 @@ impl Node {
                 send(msg, &self.network_api).await?;
                 Ok(vec![])
             }
-            NodeDuty::SendToNodes { targets, msg } => {
-                send_to_nodes(targets, &msg, &self.network_api).await?;
+            NodeDuty::SendToNodes {
+                msg,
+                targets,
+                aggregation,
+            } => {
+                send_to_nodes(&msg, targets, aggregation, &self.network_api).await?;
                 Ok(vec![])
             }
             NodeDuty::SetNodeJoinsAllowed(joins_allowed) => {

--- a/src/node/messaging.rs
+++ b/src/node/messaging.rs
@@ -38,8 +38,9 @@ pub(crate) async fn send(msg: OutgoingMsg, network: &Network) -> Result<()> {
 }
 
 pub(crate) async fn send_to_nodes(
-    targets: BTreeSet<XorName>,
     msg: &Message,
+    targets: BTreeSet<XorName>,
+    aggregation: Aggregation,
     network: &Network,
 ) -> Result<()> {
     let our_prefix = network.our_prefix().await;
@@ -58,7 +59,7 @@ pub(crate) async fn send_to_nodes(
                 Itinerary {
                     src: SrcLocation::Node(name),
                     dst: DstLocation::Node(XorName(target.0)),
-                    aggregation: Aggregation::AtDestination,
+                    aggregation,
                 },
                 bytes.clone(),
             )

--- a/src/node_ops.rs
+++ b/src/node_ops.rs
@@ -173,8 +173,9 @@ pub enum NodeDuty {
     Send(OutgoingMsg),
     /// Send the same request to each individual node.
     SendToNodes {
-        targets: BTreeSet<XorName>,
         msg: Message,
+        targets: BTreeSet<XorName>,
+        aggregation: Aggregation,
     },
     /// Process read of data
     ProcessRead {
@@ -261,8 +262,16 @@ impl Debug for NodeDuty {
             Self::IncrementFullNodeCount { .. } => write!(f, "IncrementFullNodeCount"),
             Self::SetNodeJoinsAllowed(_) => write!(f, "SetNodeJoinsAllowed"),
             Self::Send(msg) => write!(f, "Send [ msg: {:?} ]", msg),
-            Self::SendToNodes { targets, msg } => {
-                write!(f, "SendToNodes [ targets: {:?}, msg: {:?} ]", targets, msg)
+            Self::SendToNodes {
+                msg,
+                targets,
+                aggregation,
+            } => {
+                write!(
+                    f,
+                    "SendToNodes [ msg: {:?}, targets: {:?}, aggregation: {:?} ]",
+                    msg, targets, aggregation
+                )
             }
             Self::ProcessRead { .. } => write!(f, "ProcessRead"),
             Self::ProcessWrite { .. } => write!(f, "ProcessWrite"),


### PR DESCRIPTION
The cmd assumed `Aggregation::AtDestination`, since it is mostly used by
Elders. But when replicating chunk, Adults query the holders for the chunk and use the `SendToNodes` cmd.
Therefore it has to contain aggregation scheme so that Adults can set it to None.