### PR TITLE
Refactor replication flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,8 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "sn_messaging"
-version = "13.1.0"
-source = "git+https://github.com/oetyng/sn_messaging?branch=refactor-replication-flow#efdf754969da89abc4d57f981ff5cedca94a083c"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41d562c8f2d89dce55b911daad0df7dd27aa21a49f54c5ef417679b02fd944c"
 dependencies = [
  "bincode",
  "bytes 1.0.1",
@@ -2316,8 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "sn_routing"
-version = "0.59.1"
-source = "git+https://github.com/oetyng/sn_routing?branch=refactor-replication-flow#b2b052473c15293ab56ceddadd555d36fbc11cff"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349bd20d557ab1c900a8699607be8f943ee6b1d5b97b978acba6703724ef0d55"
 dependencies = [
  "bincode",
  "bls_dkg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.36.0"
+version = "0.36.2"
 dependencies = [
  "anyhow",
  "async-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,8 +2249,7 @@ dependencies = [
 [[package]]
 name = "sn_messaging"
 version = "13.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f9b5c9f8c65b3db93fc7eba61f38fa9bf07f6991856a171ea9080f5ec0af72"
+source = "git+https://github.com/oetyng/sn_messaging?branch=refactor-replication-flow#efdf754969da89abc4d57f981ff5cedca94a083c"
 dependencies = [
  "bincode",
  "bytes 1.0.1",
@@ -2318,8 +2317,7 @@ dependencies = [
 [[package]]
 name = "sn_routing"
 version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b913d4ed93c4265fa0c1adbe5f190680317947e9eb0c6d162251c0387416810"
+source = "git+https://github.com/oetyng/sn_routing?branch=refactor-replication-flow#b2b052473c15293ab56ceddadd555d36fbc11cff"
 dependencies = [
  "bincode",
  "bls_dkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,11 @@ serde_json = "1.0.53"
 structopt = "~0.3.17"
 crdts = "4.3.0"
 ed25519-dalek = "1.0.0-pre.4"
-sn_routing = "~0.59.0"
+# sn_routing = "~0.59.0"
+sn_routing = { git = "https://github.com/oetyng/sn_routing", branch = "refactor-replication-flow" }
 sn_data_types = "~0.18.0"
-sn_messaging = "~13.1.0"
+# sn_messaging = "~13.1.0"
+sn_messaging = { git = "https://github.com/oetyng/sn_messaging", branch = "refactor-replication-flow" }
 sn_transfers = "~0.7.0"
 ed25519 = "1.0.1"
 signature = "1.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,9 @@ serde_json = "1.0.53"
 structopt = "~0.3.17"
 crdts = "4.3.0"
 ed25519-dalek = "1.0.0-pre.4"
-# sn_routing = "~0.59.0"
-sn_routing = { git = "https://github.com/oetyng/sn_routing", branch = "refactor-replication-flow" }
+sn_routing = "~0.60.0"
 sn_data_types = "~0.18.0"
-# sn_messaging = "~13.1.0"
-sn_messaging = { git = "https://github.com/oetyng/sn_messaging", branch = "refactor-replication-flow" }
+sn_messaging = "~14.0.0"
 sn_transfers = "~0.7.0"
 ed25519 = "1.0.1"
 signature = "1.1.10"

--- a/src/chunks/chunk_storage.rs
+++ b/src/chunks/chunk_storage.rs
@@ -138,6 +138,7 @@ impl ChunkStorage {
         Ok(NodeDuty::SendToNodes {
             msg,
             targets: current_holders,
+            aggregation: Aggregation::None,
         })
     }
 

--- a/src/chunks/chunk_storage.rs
+++ b/src/chunks/chunk_storage.rs
@@ -118,31 +118,7 @@ impl ChunkStorage {
         }))
     }
 
-    // pub async fn replicate_chunk(
-    //     &self,
-    //     address: BlobAddress,
-    //     current_holders: BTreeSet<XorName>,
-    //     msg_id: MessageId,
-    // ) -> Result<NodeDuty> {
-    //     let msg = Message::NodeQuery {
-    //         query: NodeQuery::System(NodeSystemQuery::GetChunk {
-    //             address,
-    //             new_holder: self.node_name,
-    //             current_holders: BTreeSet::default(), //TODO: remove this in sn_messaging
-    //         }),
-    //         id: msg_id,
-    //         target_section_pk: None,
-    //     };
-    //     info!("Sending NodeSystemQuery::GetChunk to existing holders");
-
-    //     Ok(NodeDuty::SendToNodes {
-    //         msg,
-    //         targets: current_holders,
-    //         aggregation: Aggregation::None,
-    //     })
-    // }
-
-    ///
+    /// Returns a chunk to the Elders of a section.
     pub async fn get_for_replication(
         &self,
         address: BlobAddress,
@@ -172,20 +148,20 @@ impl ChunkStorage {
         }
     }
 
-    ///
-    pub async fn store_for_replication(&mut self, blob: Blob) -> Result<NodeDuty> {
+    /// Stores a chunk that Elders sent to it for replication.
+    pub async fn store_for_replication(&mut self, blob: Blob) -> Result<()> {
         if self.chunks.has(blob.address()) {
             info!(
                 "{}: Immutable chunk already exists, not storing: {:?}",
                 self,
                 blob.address()
             );
-            return Ok(NodeDuty::NoOp);
+            return Ok(());
         }
 
         self.chunks.put(&blob).await?;
 
-        Ok(NodeDuty::NoOp)
+        Ok(())
     }
 
     pub async fn used_space_ratio(&self) -> f64 {

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -71,7 +71,7 @@ impl Chunks {
         }
     }
 
-    ///
+    /// Returns a chunk to the Elders of a section.
     pub async fn get_chunk_for_replication(
         &self,
         address: BlobAddress,
@@ -84,8 +84,8 @@ impl Chunks {
             .await
     }
 
-    ///
-    pub async fn store_for_replication(&mut self, blob: Blob) -> Result<NodeDuty> {
+    /// Stores a chunk that Elders sent to it for replication.
+    pub async fn store_for_replication(&mut self, blob: Blob) -> Result<()> {
         self.chunk_storage.store_for_replication(blob).await
     }
 }

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -72,33 +72,20 @@ impl Chunks {
     }
 
     ///
-    pub async fn replicate_chunk(
-        &self,
-        address: BlobAddress,
-        current_holders: BTreeSet<XorName>,
-        msg_id: MessageId,
-    ) -> Result<NodeDuty> {
-        info!("Creating new Message for acquiring chunk from current_holders");
-        self.chunk_storage
-            .replicate_chunk(address, current_holders, msg_id)
-            .await
-    }
-
-    ///
     pub async fn get_chunk_for_replication(
         &self,
         address: BlobAddress,
         msg_id: MessageId,
-        new_holder: XorName,
+        section: XorName,
     ) -> Result<NodeDuty> {
-        info!("Send blob for replication to the new holder.");
+        info!("Send blob for replication to the Elders.");
         self.chunk_storage
-            .get_for_replication(address, msg_id, new_holder)
+            .get_for_replication(address, msg_id, section)
             .await
     }
 
     ///
-    pub async fn store_replicated_chunk(&mut self, blob: Blob) -> Result<NodeDuty> {
+    pub async fn store_for_replication(&mut self, blob: Blob) -> Result<NodeDuty> {
         self.chunk_storage.store_for_replication(blob).await
     }
 }

--- a/src/metadata/blob_register.rs
+++ b/src/metadata/blob_register.rs
@@ -127,6 +127,7 @@ impl BlobRegister {
                 id: msg_id,
                 target_section_pk: None,
             },
+            aggregation: Aggregation::AtDestination,
         })
     }
 
@@ -190,8 +191,9 @@ impl BlobRegister {
             target_section_pk: None,
         };
         Ok(NodeDuty::SendToNodes {
-            targets: metadata.holders,
             msg,
+            targets: metadata.holders,
+            aggregation: Aggregation::AtDestination,
         })
     }
 
@@ -400,8 +402,9 @@ impl BlobRegister {
             target_section_pk: None,
         };
         Ok(NodeDuty::SendToNodes {
-            targets: metadata.holders,
             msg,
+            targets: metadata.holders,
+            aggregation: Aggregation::AtDestination,
         })
     }
 

--- a/src/metadata/blob_register.rs
+++ b/src/metadata/blob_register.rs
@@ -372,10 +372,6 @@ impl BlobRegister {
     ) -> Result<NodeDuties> {
         use NodeCmd::*;
         let mut node_ops = Vec::new();
-        // let new_holders = self.get_new_holders_for_chunk(&address).await;
-        // for holder in &new_holders {
-        //     self.update_holders(address, *holder).await?;
-        // }
         let messages = current_holders
             .into_iter()
             .map(|holder| {
@@ -387,21 +383,6 @@ impl BlobRegister {
                         target_section_pk: None,
                     },
                     holder,
-                    // Ok(NodeDuty::SendToNodes {
-                    //     msg,
-                    //     targets: current_holders,
-                    //     aggregation: Aggregation::None,
-                    // })
-                    // Message::NodeCmd {
-                    //     cmd: System(NodeSystemCmd::ReplicateChunk {
-                    //         new_holder,
-                    //         address,
-                    //         current_holders: current_holders.clone(),
-                    //     }),
-                    //     id: MessageId::combine(vec![*address.name(), new_holder]),
-                    //     target_section_pk: None,
-                    // },
-                    // new_holder,
                 )
             })
             .collect::<Vec<_>>();

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -82,9 +82,6 @@ impl Metadata {
             .await
     }
 
-    // This should be called whenever a node leaves the section. It fetches the list of data that was
-    // previously held by the node and requests the remaining holders to return that chunk to us.
-    // The list of holders is also updated by removing the node that left.
     // When receiving the chunk from remaining holders, we ask new holders to store it.
     pub async fn finish_chunk_replication(&mut self, data: Blob) -> Result<NodeDuty> {
         self.elder_stores

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -359,7 +359,8 @@ impl Node {
             }
             NodeDuty::ReplicateChunk(data) => {
                 let adult = self.role.as_adult_mut()?;
-                Ok(vec![adult.chunks.store_for_replication(data).await?])
+                adult.chunks.store_for_replication(data).await?;
+                Ok(vec![])
             }
             NodeDuty::ReturnChunkToElders {
                 address,
@@ -378,23 +379,6 @@ impl Node {
                 let elder = self.role.as_elder_mut()?;
                 Ok(vec![elder.meta_data.finish_chunk_replication(data).await?])
             }
-            // NodeDuty::StoreChunkForReplication {
-            //     data,
-            //     correlation_id,
-            // } => {
-            //     // Recreate original MessageId from Section
-            //     let msg_id = MessageId::combine(vec![
-            //         *data.address().name(),
-            //         self.network_api.our_name().await,
-            //     ]);
-            //     if msg_id == correlation_id {
-            //         let adult = self.role.as_adult_mut()?;
-            //         Ok(vec![adult.chunks.store_replicated_chunk(data).await?])
-            //     } else {
-            //         log::warn!("Invalid message ID");
-            //         Ok(vec![])
-            //     }
-            // }
             NodeDuty::NoOp => Ok(vec![]),
         }
     }

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -304,8 +304,12 @@ impl Node {
                 send(msg, &self.network_api).await?;
                 Ok(vec![])
             }
-            NodeDuty::SendToNodes { targets, msg } => {
-                send_to_nodes(targets, &msg, &self.network_api).await?;
+            NodeDuty::SendToNodes {
+                msg,
+                targets,
+                aggregation,
+            } => {
+                send_to_nodes(&msg, targets, aggregation, &self.network_api).await?;
                 Ok(vec![])
             }
             NodeDuty::SetNodeJoinsAllowed(joins_allowed) => {

--- a/src/node/messaging.rs
+++ b/src/node/messaging.rs
@@ -38,8 +38,9 @@ pub(crate) async fn send(msg: OutgoingMsg, network: &Network) -> Result<()> {
 }
 
 pub(crate) async fn send_to_nodes(
-    targets: BTreeSet<XorName>,
     msg: &Message,
+    targets: BTreeSet<XorName>,
+    aggregation: Aggregation,
     network: &Network,
 ) -> Result<()> {
     let our_prefix = network.our_prefix().await;
@@ -58,7 +59,7 @@ pub(crate) async fn send_to_nodes(
                 Itinerary {
                     src: SrcLocation::Node(name),
                     dst: DstLocation::Node(XorName(target.0)),
-                    aggregation: Aggregation::AtDestination,
+                    aggregation,
                 },
                 bytes.clone(),
             )

--- a/src/node_ops.rs
+++ b/src/node_ops.rs
@@ -207,12 +207,6 @@ pub enum NodeDuty {
         id: MessageId,
         section: XorName,
     },
-    // /// Store a chunk that is a result of data replication
-    // /// on `MemberLeft`
-    // StoreChunkForReplication {
-    //     data: Blob,
-    //     correlation_id: MessageId,
-    // },
     NoOp,
 }
 

--- a/src/node_ops.rs
+++ b/src/node_ops.rs
@@ -173,8 +173,9 @@ pub enum NodeDuty {
     Send(OutgoingMsg),
     /// Send the same request to each individual node.
     SendToNodes {
-        targets: BTreeSet<XorName>,
         msg: Message,
+        targets: BTreeSet<XorName>,
+        aggregation: Aggregation,
     },
     /// Process read of data
     ProcessRead {
@@ -261,8 +262,16 @@ impl Debug for NodeDuty {
             Self::IncrementFullNodeCount { .. } => write!(f, "IncrementFullNodeCount"),
             Self::SetNodeJoinsAllowed(_) => write!(f, "SetNodeJoinsAllowed"),
             Self::Send(msg) => write!(f, "Send [ msg: {:?} ]", msg),
-            Self::SendToNodes { targets, msg } => {
-                write!(f, "SendToNodes [ targets: {:?}, msg: {:?} ]", targets, msg)
+            Self::SendToNodes {
+                msg,
+                targets,
+                aggregation,
+            } => {
+                write!(
+                    f,
+                    "SendToNodes [ msg: {:?}, targets: {:?}, aggregation: {:?} ]",
+                    msg, targets, aggregation
+                )
             }
             Self::ProcessRead { .. } => write!(f, "ProcessRead"),
             Self::ProcessWrite { .. } => write!(f, "ProcessWrite"),

--- a/src/node_ops.rs
+++ b/src/node_ops.rs
@@ -194,28 +194,25 @@ pub enum NodeDuty {
         msg: Message,
         origin: EndUser,
     },
-    /// Process replication of a chunk on `MemberLeft`
-    /// This is run at the node which is the new holder
-    /// of a chunk
-    ReplicateChunk {
+    ///
+    FinishReplication(Blob),
+    /// Receive a chunk that is being replicated.
+    /// This is run at an Adult (the new holder).
+    ReplicateChunk(Blob),
+    /// Retrieve a chunk
+    /// and send it back to to the requesting Elders
+    /// for them to replicate it on new nodes.
+    ReturnChunkToElders {
         address: BlobAddress,
-        current_holders: BTreeSet<XorName>,
         id: MessageId,
+        section: XorName,
     },
-    /// Process a GetChunk operation
-    /// and send it back to to the requesting node
-    /// for replication
-    GetChunkForReplication {
-        address: BlobAddress,
-        new_holder: XorName,
-        id: MessageId,
-    },
-    /// Store a chunk that is a result of data replication
-    /// on `MemberLeft`
-    StoreChunkForReplication {
-        data: Blob,
-        correlation_id: MessageId,
-    },
+    // /// Store a chunk that is a result of data replication
+    // /// on `MemberLeft`
+    // StoreChunkForReplication {
+    //     data: Blob,
+    //     correlation_id: MessageId,
+    // },
     NoOp,
 }
 
@@ -254,7 +251,6 @@ impl Debug for NodeDuty {
             Self::EldersChanged { .. } => write!(f, "EldersChanged"),
             Self::SectionSplit { .. } => write!(f, "SectionSplit"),
             Self::GetSectionElders { .. } => write!(f, "GetSectionElders"),
-
             Self::NoOp => write!(f, "No op."),
             Self::ReachingMaxCapacity => write!(f, "ReachingMaxCapacity"),
             Self::ProcessLostMember { .. } => write!(f, "ProcessLostMember"),
@@ -276,9 +272,9 @@ impl Debug for NodeDuty {
             Self::ProcessRead { .. } => write!(f, "ProcessRead"),
             Self::ProcessWrite { .. } => write!(f, "ProcessWrite"),
             Self::ProcessDataPayment { .. } => write!(f, "ProcessDataPayment"),
-            Self::ReplicateChunk { .. } => write!(f, "ReplicateChunk"),
-            Self::GetChunkForReplication { .. } => write!(f, "GetChunkForReplication"),
-            Self::StoreChunkForReplication { .. } => write!(f, "StoreChunkForReplication"),
+            Self::ReturnChunkToElders { .. } => write!(f, "ReturnChunkToElders"),
+            Self::FinishReplication(_) => write!(f, "FinishReplication"),
+            Self::ReplicateChunk(_) => write!(f, "ReplicateChunk"),
         }
     }
 }


### PR DESCRIPTION
- Refactor of the replication flow:
Adult to Adult connectivity is not guaranteed,
so we have Elders collect the chunks and send them out to new holders.

- Also fixes the `MissingSecretKeyShare` bug:
The cmd assumed `Aggregation::AtDestination`, since it is mostly used by
Elders. But when replicating chunk, Adults query the holders for the chunk and use the `SendToNodes` cmd.
Therefore it has to contain aggregation scheme so that Adults can set it to None.