### PR TITLE
chore(cicd): stop publishing this crate on crates.io as not a lib

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -218,31 +218,3 @@ jobs:
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
           asset_content_type: application/zip
-
-  # Publish if we're on a `chore(release):` commit
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs: [deploy]
-    if: |
-      github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
-    steps:
-      - uses: actions/checkout@v2
-      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
-        with:
-          fetch-depth: '0'
-
-      # Install Rust
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      # Publish to crates.io.
-      - name: Cargo Login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Cargo Publish
-        run: cargo publish --allow-dirty

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -200,21 +200,3 @@ jobs:
       run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
 
     - uses: EmbarkStudios/cargo-deny-action@v1
-
-  # Test publish using --dry-run.
-  test-publish:
-    if: github.repository_owner == 'maidsafe'
-    name: Test Publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Test publish
-        run: cargo publish --allow-dirty --dry-run

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sn_node
 
-|Crate|Documentation|Safe Rust|
+|Documentation|Safe Rust|
 |:---:|:-----------:|:-------:|
-|[![](http://meritbadge.herokuapp.com/sn_node)](https://crates.io/crates/sn_node)|[![Documentation](https://docs.rs/sn_node/badge.svg)](https://docs.rs/sn_node)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+|[![Documentation](https://docs.rs/sn_node/badge.svg)](https://docs.rs/sn_node)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 | [MaidSafe website](https://maidsafe.net) | [Safe Dev Forum](https://forum.safedev.org) | [Safe Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|


### PR DESCRIPTION
crates.io is intended for libs, not crates such as this which produce a bin.
Removing publish steps from ci/cd.

Separate to this PR I'll upload to crates.io so that the text there explains that this is no longer published on crates.io