### PR TITLE
chore(refactor): use atomics for UsedStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.37.5"
+version = "0.37.8"
 dependencies = [
  "anyhow",
  "async-log",

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -61,7 +61,7 @@ where
     ///
     /// The maximum storage space is defined by `max_capacity`.  This specifies the max usable by
     /// _all_ `ChunkStores`, not per `ChunkStore`.
-    pub async fn new<P: AsRef<Path>>(root: P, used_space: UsedSpace) -> Result<Self> {
+    pub async fn new<P: AsRef<Path>>(root: P, mut used_space: UsedSpace) -> Result<Self> {
         let dir = root.as_ref().join(CHUNK_STORE_DIR).join(Self::subdir());
 
         if fs::read(&dir).is_err() {
@@ -102,18 +102,15 @@ impl<T: Chunk> ChunkStore<T> {
         let consumed_space = serialised_chunk.len() as u64;
 
         info!("consumed space: {:?}", consumed_space);
-        info!("max : {:?}", self.used_space.max_capacity().await);
-        info!("use space total : {:?}", self.used_space.total().await);
+        info!("max : {:?}", self.used_space.max_capacity());
+        info!("use space total : {:?}", self.used_space.total());
 
         let file_path = self.file_path(chunk.id())?;
         self.do_delete(&file_path).await?;
 
         // pre-reserve space
         self.used_space.increase(self.id, consumed_space).await?;
-        trace!(
-            "use space total after add: {:?}",
-            self.used_space.total().await
-        );
+        trace!("use space total after add: {:?}", self.used_space.total());
 
         let res = File::create(&file_path).and_then(|mut file| {
             file.write_all(&serialised_chunk)?;
@@ -143,8 +140,8 @@ impl<T: Chunk> ChunkStore<T> {
 
     /// Used space to max space ratio.
     pub async fn used_space_ratio(&self) -> f64 {
-        let used = self.total_used_space().await;
-        let total = self.used_space.max_capacity().await;
+        let used = self.total_used_space();
+        let total = self.used_space.max_capacity();
         let used_space_ratio = used as f64 / total as f64;
         info!("Used space: {:?}", used);
         info!("Total space: {:?}", total);
@@ -168,8 +165,8 @@ impl<T: Chunk> ChunkStore<T> {
         }
     }
 
-    pub async fn total_used_space(&self) -> u64 {
-        self.used_space.total().await
+    pub fn total_used_space(&self) -> u64 {
+        self.used_space.total()
     }
 
     /// Tests if a data chunk has been previously stored under `id`.

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -128,8 +128,6 @@ impl<T: Chunk> ChunkStore<T> {
         let file_path = self.file_path(chunk.id())?;
         self.do_delete(&file_path).await?;
 
-        // pre-reserve space
-        dbg!(&self.used_space.total());
         self.used_space.increase(self.id, consumed_space).await?;
         trace!("use space total after add: {:?}", self.used_space.total());
 

--- a/src/chunk_store/tests.rs
+++ b/src/chunk_store/tests.rs
@@ -8,7 +8,7 @@
 
 use super::{
     chunk::{Chunk, ChunkId},
-    ChunkStore, Result as ChunkStoreResult, Subdir, UsedSpace,
+    ChunkStore, Result as ChunkStoreResult, Subdir,
 };
 use crate::{to_db_key::ToDbKey, Error, Result};
 use rand::{distributions::Standard, rngs::ThreadRng, Rng};
@@ -145,7 +145,6 @@ async fn delete() -> Result<()> {
     let chunks = Chunks::gen(&mut rng)?;
 
     let root = temp_dir()?;
-    let used_space = UsedSpace::new(u64::MAX);
     let mut chunk_store = ChunkStore::new(root.path(), u64::MAX).await?;
 
     for (index, (data, size)) in chunks.data_and_sizes.iter().enumerate() {

--- a/src/chunk_store/tests.rs
+++ b/src/chunk_store/tests.rs
@@ -86,8 +86,7 @@ async fn successful_put() -> Result<()> {
     let chunks = Chunks::gen(&mut rng)?;
 
     let root = temp_dir()?;
-    let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::<Data>::new(root.path(), used_space.clone()).await?;
+    let mut chunk_store = ChunkStore::<Data>::new(root.path(), u64::MAX).await?;
 
     for (index, (data, size)) in chunks.data_and_sizes.iter().enumerate().rev() {
         let the_data = &Data {
@@ -121,9 +120,8 @@ async fn successful_put() -> Result<()> {
 async fn failed_put_when_not_enough_space() -> Result<()> {
     let mut rng = new_rng();
     let root = temp_dir()?;
-    let capacity = 32;
-    let used_space = UsedSpace::new(capacity);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
+    let capacity = 32u64;
+    let mut chunk_store = ChunkStore::new(root.path(), 32).await?;
 
     let data = Data {
         id: Id(rng.gen()),
@@ -148,7 +146,7 @@ async fn delete() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), u64::MAX).await?;
 
     for (index, (data, size)) in chunks.data_and_sizes.iter().enumerate() {
         let the_data = &Data {
@@ -172,8 +170,7 @@ async fn put_and_get_value_should_be_same() -> Result<()> {
     let chunks = Chunks::gen(&mut rng)?;
 
     let root = temp_dir()?;
-    let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), u64::MAX).await?;
 
     for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
         chunk_store
@@ -198,8 +195,7 @@ async fn overwrite_value() -> Result<()> {
     let chunks = Chunks::gen(&mut rng)?;
 
     let root = temp_dir()?;
-    let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), u64::MAX).await?;
 
     for (data, size) in chunks.data_and_sizes {
         chunk_store
@@ -219,8 +215,7 @@ async fn overwrite_value() -> Result<()> {
 #[tokio::test]
 async fn get_fails_when_key_does_not_exist() -> Result<()> {
     let root = temp_dir()?;
-    let used_space = UsedSpace::new(u64::MAX);
-    let chunk_store: ChunkStore<Data> = ChunkStore::new(root.path(), used_space.clone()).await?;
+    let chunk_store: ChunkStore<Data> = ChunkStore::new(root.path(), u64::MAX).await?;
 
     let id = Id(new_rng().gen());
     match chunk_store.get(&id) {
@@ -237,8 +232,7 @@ async fn keys() -> Result<()> {
     let chunks = Chunks::gen(&mut rng)?;
 
     let root = temp_dir()?;
-    let used_space = UsedSpace::new(u64::MAX);
-    let mut chunk_store = ChunkStore::new(root.path(), used_space.clone()).await?;
+    let mut chunk_store = ChunkStore::new(root.path(), u64::MAX).await?;
 
     for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
         let id = Id(index as u64);

--- a/src/chunk_store/tests.rs
+++ b/src/chunk_store/tests.rs
@@ -94,16 +94,16 @@ async fn successful_put() -> Result<()> {
             id: Id(index as u64),
             value: data.clone(),
         };
-        let used_space_before = chunk_store.total_used_space().await;
+        let used_space_before = chunk_store.total_used_space();
         assert!(!chunk_store.has(&the_data.id));
         chunk_store.put(the_data).await?;
-        let used_space_after = chunk_store.total_used_space().await;
+        let used_space_after = chunk_store.total_used_space();
         assert_eq!(used_space_after, used_space_before + size);
         assert!(chunk_store.has(&the_data.id));
         assert!(used_space_after <= chunks.total_size);
     }
 
-    assert_eq!(chunk_store.total_used_space().await, chunks.total_size);
+    assert_eq!(chunk_store.total_used_space(), chunks.total_size);
 
     let mut keys = chunk_store.keys();
     keys.sort();
@@ -156,11 +156,11 @@ async fn delete() -> Result<()> {
             value: data.clone(),
         };
         chunk_store.put(the_data).await?;
-        assert_eq!(chunk_store.total_used_space().await, *size);
+        assert_eq!(chunk_store.total_used_space(), *size);
         assert!(chunk_store.has(&the_data.id));
         chunk_store.delete(&the_data.id).await?;
         assert!(!chunk_store.has(&the_data.id));
-        assert_eq!(chunk_store.total_used_space().await, 0);
+        assert_eq!(chunk_store.total_used_space(), 0);
     }
 
     Ok(())
@@ -208,7 +208,7 @@ async fn overwrite_value() -> Result<()> {
                 value: data.clone(),
             })
             .await?;
-        assert_eq!(chunk_store.total_used_space().await, size);
+        assert_eq!(chunk_store.total_used_space(), size);
         let retrieved_data = chunk_store.get(&Id(0))?;
         assert_eq!(data, retrieved_data.value);
     }

--- a/src/chunk_store/used_space.rs
+++ b/src/chunk_store/used_space.rs
@@ -7,261 +7,208 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{Error, Result};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{path::Path, sync::Arc};
-use tokio::{io::AsyncSeekExt, sync::Mutex};
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncReadExt, SeekFrom};
+use tokio::sync::RwLock;
+use tokio::{io::AsyncSeekExt, io::AsyncWriteExt};
 
 const USED_SPACE_FILENAME: &str = "used_space";
-
-/// This holds a record (in-memory and on-disk) of the space used by a single `ChunkStore`, and also
-/// an in-memory record of the total space used by all `ChunkStore`s.
-#[derive(Debug, Clone)]
-pub struct UsedSpace {
-    inner: Arc<Mutex<inner::UsedSpace>>,
-}
 
 /// Identifies a `ChunkStore` within the larger
 /// used space tracking
 pub type StoreId = u64;
 
-impl UsedSpace {
-    /// construct a new used space instance
-    /// NOTE: this constructs a new async-safe instance,
-    /// If you intend to create a new local `ChunkStore` tracking,
-    /// then use `clone()` and `add_local_store()` to ensure
-    /// consistency across local `ChunkStore`s
-    pub fn new(max_capacity: u64) -> Self {
+#[derive(Debug)]
+/// This holds a record (in-memory and on-disk) of the space used by a single `ChunkStore`, and also
+/// an in-memory record of the total space used by all `ChunkStore`s. It tracks the Used Space of all `ChunkStore` objects
+/// registered with it, as well as the combined amount
+pub struct UsedSpace {
+    max_capacity: AtomicU64,
+    total_value: AtomicU64,
+    local_stores: Arc<RwLock<HashMap<StoreId, LocalUsedSpace>>>,
+    next_id: AtomicU64,
+}
+
+// Atomic types do not implement Clone so this is a hack done by creating new atomic type from the
+// inner value.
+impl Clone for UsedSpace {
+    fn clone(&self) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(inner::UsedSpace::new(max_capacity))),
+            max_capacity: AtomicU64::new(self.max_capacity.load(Ordering::SeqCst)),
+            total_value: AtomicU64::new(self.max_capacity.load(Ordering::SeqCst)),
+            local_stores: self.local_stores.clone(),
+            next_id: AtomicU64::new(self.next_id.load(Ordering::SeqCst)),
         }
-    }
-
-    /// Clears the entire storage and sets total_value back to zero
-    /// while removing all local stores
-    pub async fn reset(&self) -> Result<()> {
-        self.inner.lock().await.reset().await
-    }
-
-    /// Returns the maximum capacity (e.g. the maximum
-    /// value that total() can return)
-    pub async fn max_capacity(&self) -> u64 {
-        self.inner.lock().await.max_capacity()
-    }
-
-    /// Returns the total used space as a snapshot
-    /// Note, due to the async nature of this, the value
-    /// may be stale by the time it is read if there are multiple
-    /// writers
-    pub async fn total(&self) -> u64 {
-        self.inner.lock().await.total()
-    }
-
-    /// Returns the used space of a local store as a snapshot
-    /// Note, due to the async nature of this, the value
-    /// may be stale by the time it is read if there are multiple
-    /// writers
-    #[allow(unused)]
-    pub async fn local(&self, id: StoreId) -> u64 {
-        self.inner.lock().await.local(id)
-    }
-
-    /// Add an object and file store to track used space of a single
-    /// `ChunkStore`
-    pub async fn add_local_store<T: AsRef<Path>>(&self, dir: T) -> Result<StoreId> {
-        self.inner.lock().await.add_local_store(dir).await
-    }
-
-    /// Increase the used amount of a single chunk store and the global used value
-    pub async fn increase(&self, id: StoreId, consumed: u64) -> Result<()> {
-        self.inner.lock().await.increase(id, consumed).await
-    }
-
-    /// Decrease the used amount of a single chunk store and the global used value
-    pub async fn decrease(&self, id: StoreId, released: u64) -> Result<()> {
-        self.inner.lock().await.decrease(id, released).await
     }
 }
 
-mod inner {
-
-    use super::*;
-    use std::{collections::HashMap, io::SeekFrom};
-    use tokio::{
-        fs::{File, OpenOptions},
-        io::{AsyncReadExt, AsyncWriteExt},
-    };
-
-    /// Tracks the Used Space of all `ChunkStore` objects
-    /// registered with it, as well as the combined amount
-    #[derive(Debug)]
-    pub struct UsedSpace {
-        /// the maximum value (inclusive) that `total_value` can attain
-        max_capacity: u64,
-        /// Total space consumed across all `ChunkStore`s, including this one
-        total_value: u64,
-        /// the used space tracking for each chunk store
-        local_stores: HashMap<StoreId, LocalUsedSpace>,
-        /// next local `ChunkStore` id to use
-        next_id: StoreId,
+impl UsedSpace {
+    pub fn new(max_capacity: u64) -> UsedSpace {
+        UsedSpace {
+            max_capacity: AtomicU64::new(max_capacity),
+            total_value: AtomicU64::default(),
+            local_stores: Arc::new(RwLock::new(HashMap::<u64, LocalUsedSpace>::new())),
+            next_id: Default::default(),
+        }
     }
 
-    /// An entry used to track the used space of a single `ChunkStore`
-    #[derive(Debug)]
-    struct LocalUsedSpace {
-        // Space consumed by this one `ChunkStore`.
-        pub local_value: u64,
-        // File used to maintain on-disk record of `local_value`.
-        // TODO: maybe a good idea to maintain a journal that is only flushed occasionally
-        // to ensure stale entries aren't recorded, and to avoid holding the lock for the
-        // whole inner::UsedSpace struct during the entirety of the file write.
-        pub local_record: File,
+    /// Clears the storage, setting total value ot zero
+    /// and dropping local stores, but leaves
+    /// the capacity and next_id unchanged
+    pub async fn reset(&self) -> Result<()> {
+        self.total_value.store(0, Ordering::SeqCst);
+
+        let store = &mut *self.local_stores.write().await;
+        for (_, local_used_space) in store.iter_mut() {
+            local_used_space.local_value = 0;
+            write_local_to_file(&mut local_used_space.local_record, 0u64).await?;
+        }
+
+        Ok(())
     }
 
-    impl UsedSpace {
-        pub fn new(max_capacity: u64) -> Self {
-            Self {
-                max_capacity,
-                total_value: 0u64,
-                local_stores: HashMap::new(),
-                next_id: 0u64,
-            }
-        }
+    #[inline]
+    /// Returns the maximum capacity (e.g. the maximum
+    /// value that total() can return)
+    pub fn max_capacity(&self) -> u64 {
+        self.max_capacity.load(Ordering::SeqCst)
+    }
 
-        /// Clears the storage, setting total value ot zero
-        /// and dropping local stores, but leaves
-        /// the capacity and next_id unchanged
-        pub async fn reset(&mut self) -> Result<()> {
-            self.total_value = 0;
-            for (_id, local_used_space) in self.local_stores.iter_mut() {
-                local_used_space.local_value = 0;
-                Self::write_local_to_file(&mut local_used_space.local_record, 0).await?;
-            }
-            Ok(())
-        }
+    #[inline]
+    /// Returns the total used space
+    pub fn total(&self) -> u64 {
+        self.total_value.load(Ordering::SeqCst)
+    }
 
-        /// Returns the maximum capacity (e.g. the maximum
-        /// value that total() can return)
-        pub fn max_capacity(&self) -> u64 {
-            self.max_capacity
-        }
+    /// Returns the used space of a local store as a snapshot
+    #[allow(dead_code)]
+    pub async fn local(&self, id: StoreId) -> u64 {
+        self.local_stores
+            .read()
+            .await
+            .get(&id)
+            .map_or(0, |res| res.local_value)
+    }
 
-        /// Returns the total used space
-        pub fn total(&self) -> u64 {
-            self.total_value
-        }
+    /// Adds a new record for tracking the actions
+    /// of a local chunk store as part of the global
+    /// used amount tracking
+    pub async fn add_local_store<T: AsRef<Path>>(&mut self, dir: T) -> Result<StoreId> {
+        let mut local_record = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(dir.as_ref().join(USED_SPACE_FILENAME))
+            .await?;
 
-        /// Returns the used space of a local store as a snapshot
-        pub fn local(&self, id: StoreId) -> u64 {
-            self.local_stores.get(&id).map_or(0, |res| res.local_value)
-        }
+        let mut buffer = Vec::<u8>::with_capacity(8);
+        let read_byte = local_record.read_to_end(&mut buffer).await?;
+        let local_value = if read_byte > 0 {
+            bincode::deserialize::<u64>(&buffer)?
+        } else {
+            let mut bytes = Vec::<u8>::with_capacity(8);
+            bincode::serialize_into(&mut bytes, &0_u64)?;
+            local_record.write_all(&bytes).await?;
+            0
+        };
 
-        /// Adds a new record for tracking the actions
-        /// of a local chunk store as part of the global
-        /// used amount tracking
-        pub async fn add_local_store<T: AsRef<Path>>(&mut self, dir: T) -> Result<StoreId> {
-            let mut local_record = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .open(dir.as_ref().join(USED_SPACE_FILENAME))
-                .await?;
+        let local_store = LocalUsedSpace::new(local_value, local_record);
 
-            // try read
-            let mut buffer = vec![];
-            let could_read = local_record.read_to_end(&mut buffer).await.is_ok();
-            let has_value = !buffer.is_empty();
-            let local_value = if could_read && has_value {
-                // TODO - if this can't be parsed, we should consider emptying `dir` of any chunks.
-                bincode::deserialize::<u64>(&buffer)?
-            } else {
-                let mut bytes = Vec::<u8>::new();
-                bincode::serialize_into(&mut bytes, &0_u64)?;
-                local_record.write_all(&bytes).await?;
-                0
-            };
+        let mut store = self.local_stores.write().await;
+        let _ = self.next_id.fetch_add(1u64, Ordering::SeqCst);
+        let next = self.next_id.load(Ordering::SeqCst);
+        let _ = store.insert(next, local_store);
+        Ok(next)
+    }
 
-            let local_store = LocalUsedSpace {
-                local_value,
-                local_record,
-            };
-            let id = self.next_id;
-            self.next_id += 1;
-            let _ = self.local_stores.insert(id, local_store);
-            Ok(id)
-        }
+    /// Increase used space in a local store and globally at the same time
+    pub async fn increase(&self, id: StoreId, consumed: u64) -> Result<()> {
+        self.change_value(id, consumed, false).await
+    }
 
-        /// Increase used space in a local store and globally at the same time
-        pub async fn increase(&mut self, id: StoreId, consumed: u64) -> Result<()> {
-            let new_total = self
+    /// Decrease used space in a local store and globally at the same time
+    pub async fn decrease(&self, id: StoreId, consumed: u64) -> Result<()> {
+        self.change_value(id, consumed, true).await
+    }
+
+    async fn change_value(&self, id: u64, consumed: u64, reverse: bool) -> Result<()> {
+        let total = self.total_value.load(Ordering::SeqCst);
+        if total <= self.max_capacity.load(Ordering::SeqCst) {
+            let _ = self
                 .total_value
-                .checked_add(consumed)
-                .ok_or(Error::NotEnoughSpace)?;
-            if new_total > self.max_capacity {
-                return Err(Error::NotEnoughSpace);
-            }
-            let new_local = self
-                .local_stores
-                .get(&id)
-                .ok_or(Error::NoStoreId)?
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |t| {
+                    if reverse {
+                        Some(t.saturating_sub(consumed))
+                    } else {
+                        t.checked_add(consumed)
+                    }
+                })
+                .map_err(|_| Error::NotEnoughSpace)?;
+        } else {
+            return Err(Error::NotEnoughSpace);
+        }
+        let mut local_stores = self.local_stores.write().await;
+
+        let local_used_space = local_stores.get(&id).ok_or(Error::NoStoreId)?;
+        let new_local = if reverse {
+            local_used_space.local_value.saturating_sub(consumed)
+        } else {
+            local_used_space
                 .local_value
                 .checked_add(consumed)
-                .ok_or(Error::NotEnoughSpace)?;
+                .ok_or(Error::NotEnoughSpace)?
+        };
+        let record = &mut local_stores
+            .get_mut(&id)
+            .ok_or(Error::NoStoreId)?
+            .local_record;
 
-            {
-                let record = &mut self
-                    .local_stores
-                    .get_mut(&id)
-                    .ok_or(Error::NoStoreId)?
-                    .local_record;
-                Self::write_local_to_file(record, new_local).await?;
-            }
-            self.total_value = new_total;
-            self.local_stores
-                .get_mut(&id)
-                .ok_or(Error::NoStoreId)?
-                .local_value = new_local;
+        write_local_to_file(record, new_local).await?;
 
-            Ok(())
-        }
+        local_stores
+            .get_mut(&id)
+            .ok_or(Error::NoStoreId)?
+            .local_value = new_local;
 
-        /// Decrease used space in a local store and globally at the same time
-        pub async fn decrease(&mut self, id: StoreId, released: u64) -> Result<()> {
-            let new_local = self
-                .local_stores
-                .get_mut(&id)
-                .ok_or(Error::NoStoreId)?
-                .local_value
-                .saturating_sub(released);
+        Ok(())
+    }
+}
 
-            let new_total = self.total_value.saturating_sub(released);
-            {
-                let record = &mut self
-                    .local_stores
-                    .get_mut(&id)
-                    .ok_or(Error::NoStoreId)?
-                    .local_record;
-                Self::write_local_to_file(record, new_local).await?;
-            }
-            self.total_value = new_total;
-            self.local_stores
-                .get_mut(&id)
-                .ok_or(Error::NoStoreId)?
-                .local_value = new_local;
-            Ok(())
-        }
+/// helper to write the contents of local to file
+/// NOTE: For now, you should hold the lock on the inner while doing this
+/// It's slow, but maintains behaviour from the previous implementation
+async fn write_local_to_file(record: &mut File, local: u64) -> Result<()> {
+    record.set_len(0).await?;
+    let _ = record.seek(SeekFrom::Start(0u64)).await?;
 
-        /// helper to write the contents of local to file
-        /// NOTE: For now, you should hold the lock on the inner while doing this
-        /// It's slow, but maintains behaviour from the previous implementation
-        async fn write_local_to_file(record: &mut File, local: u64) -> Result<()> {
-            record.set_len(0).await?;
-            let _ = record.seek(SeekFrom::Start(0)).await?;
+    let mut contents = Vec::<u8>::with_capacity(8);
+    bincode::serialize_into(&mut contents, &local)?;
+    record.write_all(&contents).await?;
+    record.sync_all().await?;
 
-            let mut contents = Vec::<u8>::new();
-            bincode::serialize_into(&mut contents, &local)?;
-            record.write_all(&contents).await?;
-            record.sync_all().await?;
+    Ok(())
+}
 
-            Ok(())
+/// An entry used to track the used space of a single `ChunkStore`
+#[derive(Debug)]
+struct LocalUsedSpace {
+    // Space consumed by this one `ChunkStore`.
+    pub local_value: u64,
+    // File used to maintain on-disk record of `local_value`.
+    // TODO: maybe a good idea to maintain a journal that is only flushed occasionally
+    // to ensure stale entries aren't recorded, and to avoid holding the lock for the
+    // whole inner::UsedSpace struct during the entirety of the file write.
+    pub local_record: File,
+}
+
+impl LocalUsedSpace {
+    pub fn new(value: u64, record: File) -> LocalUsedSpace {
+        LocalUsedSpace {
+            local_value: value,
+            local_record: record,
         }
     }
 }
@@ -290,11 +237,10 @@ mod tests {
     #[tokio::test]
     async fn used_space_multiwriter_test() -> Result<()> {
         const NUMS_TO_ADD: usize = 128;
-
         // alloc store
         let root_dir = create_temp_root()?;
         let store_dir = create_temp_store(&root_dir)?;
-        let used_space = UsedSpace::new(TEST_STORE_MAX_SIZE);
+        let mut used_space = UsedSpace::new(TEST_STORE_MAX_SIZE);
         let id = used_space.add_local_store(&store_dir).await?;
         // get a random vec of u64 by adding u32 (avoid overflow)
         let mut rng = rand::thread_rng();
@@ -310,13 +256,14 @@ mod tests {
         let total: u64 = nums.iter().sum();
 
         // check that multiwriter increase is consistent
-        let mut tasks = Vec::new();
-        for n in nums.iter() {
-            tasks.push(used_space.increase(id, *n));
-        }
+        let tasks = nums
+            .iter()
+            .map(|n| used_space.increase(id, *n))
+            .collect::<Vec<_>>();
+
         let _ = futures::future::try_join_all(tasks.into_iter()).await?;
 
-        assert_eq!(total, used_space.total().await);
+        assert_eq!(total, used_space.total());
         assert_eq!(total, used_space.local(id).await);
 
         // check that multiwriter decrease is consistent
@@ -326,8 +273,8 @@ mod tests {
         }
         let _ = futures::future::try_join_all(tasks.into_iter()).await?;
 
-        assert_eq!(0, used_space.total().await);
-        assert_eq!(0, used_space.local(id).await);
+        assert_eq!(0u64, used_space.total());
+        assert_eq!(0u64, used_space.local(id).await);
 
         Ok(())
     }

--- a/src/chunks/chunk_storage.rs
+++ b/src/chunks/chunk_storage.rs
@@ -33,8 +33,14 @@ pub(crate) struct ChunkStorage {
 }
 
 impl ChunkStorage {
-    pub(crate) async fn new(path: &Path, used_space: UsedSpace) -> Result<Self> {
-        let chunks = BlobChunkStore::new(path, used_space).await?;
+    pub(crate) async fn new(path: &Path, max_capacity: u64) -> Result<Self> {
+        let chunks = BlobChunkStore::new(path, max_capacity).await?;
+        Ok(Self { chunks })
+    }
+
+    pub(crate) async fn from_used_space(path: &Path, used_space: &mut UsedSpace) -> Result<Self> {
+        let chunks = BlobChunkStore::from_used_space(path, used_space).await?;
+
         Ok(Self { chunks })
     }
 
@@ -237,7 +243,7 @@ mod tests {
     #[tokio::test]
     pub async fn try_store_stores_public_blob() -> Result<()> {
         let path = PathBuf::from(temp_dir()?.path());
-        let mut storage = ChunkStorage::new(&path, UsedSpace::new(u64::MAX)).await?;
+        let mut storage = ChunkStorage::new(&path, u64::MAX).await?;
         let value = "immutable data value".to_owned().into_bytes();
         let blob = Blob::Public(PublicBlob::new(value));
         assert!(storage
@@ -252,7 +258,7 @@ mod tests {
     #[tokio::test]
     pub async fn try_store_stores_private_blob() -> Result<()> {
         let path = PathBuf::from(temp_dir()?.path());
-        let mut storage = ChunkStorage::new(&path, UsedSpace::new(u64::MAX)).await?;
+        let mut storage = ChunkStorage::new(&path, u64::MAX).await?;
         let value = "immutable data value".to_owned().into_bytes();
         let key = get_random_pk();
         let blob = Blob::Private(PrivateBlob::new(value, key));
@@ -268,7 +274,7 @@ mod tests {
     #[tokio::test]
     pub async fn try_store_errors_if_end_user_doesnt_own_data() -> Result<()> {
         let path = PathBuf::from(temp_dir()?.path());
-        let mut storage = ChunkStorage::new(&path, UsedSpace::new(u64::MAX)).await?;
+        let mut storage = ChunkStorage::new(&path, u64::MAX).await?;
         let value = "immutable data value".to_owned().into_bytes();
         let data_owner = get_random_pk();
         let end_user = get_random_pk();

--- a/src/chunks/chunk_storage.rs
+++ b/src/chunks/chunk_storage.rs
@@ -224,7 +224,6 @@ impl Display for ChunkStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk_store::UsedSpace;
     use crate::error::Error::InvalidOwners;
     use crate::error::Result;
     use bls::SecretKey;

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -37,9 +37,15 @@ pub(crate) struct Chunks {
 }
 
 impl Chunks {
-    pub async fn new(path: &Path, used_space: UsedSpace) -> Result<Self> {
+    pub async fn new(path: &Path, max_capacity: u64) -> Result<Self> {
         Ok(Self {
-            chunk_storage: ChunkStorage::new(path, used_space).await?,
+            chunk_storage: ChunkStorage::new(path, max_capacity).await?,
+        })
+    }
+
+    pub async fn from_used_space(path: &Path, used_space: &mut UsedSpace) -> Result<Self> {
+        Ok(Self {
+            chunk_storage: ChunkStorage::from_used_space(path, used_space).await?,
         })
     }
 

--- a/src/metadata/map_storage.rs
+++ b/src/metadata/map_storage.rs
@@ -33,8 +33,13 @@ pub(super) struct MapStorage {
 }
 
 impl MapStorage {
-    pub(super) async fn new(path: &Path, used_space: UsedSpace) -> Result<Self> {
-        let chunks = MapChunkStore::new(path, used_space).await?;
+    pub(super) async fn new(path: &Path, max_capacity: u64) -> Result<Self> {
+        let chunks = MapChunkStore::new(path, max_capacity).await?;
+        Ok(Self { chunks })
+    }
+
+    pub(super) async fn from_used_space(path: &Path, used_space: &mut UsedSpace) -> Result<Self> {
+        let chunks = MapChunkStore::from_used_space(path, used_space).await?;
         Ok(Self { chunks })
     }
 

--- a/src/metadata/map_storage.rs
+++ b/src/metadata/map_storage.rs
@@ -33,6 +33,7 @@ pub(super) struct MapStorage {
 }
 
 impl MapStorage {
+    #[allow(dead_code)]
     pub(super) async fn new(path: &Path, max_capacity: u64) -> Result<Self> {
         let chunks = MapChunkStore::new(path, max_capacity).await?;
         Ok(Self { chunks })

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -43,6 +43,7 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    #[allow(dead_code)]
     pub async fn new(
         path: &Path,
         max_capacity: u64,

--- a/src/metadata/sequence_storage.rs
+++ b/src/metadata/sequence_storage.rs
@@ -33,6 +33,7 @@ pub(super) struct SequenceStorage {
 }
 
 impl SequenceStorage {
+    #[allow(dead_code)]
     pub(super) async fn new(path: &Path, max_capacity: u64) -> Result<Self> {
         let chunks = SequenceChunkStore::new(path, max_capacity).await?;
         Ok(Self { chunks })

--- a/src/metadata/sequence_storage.rs
+++ b/src/metadata/sequence_storage.rs
@@ -33,8 +33,13 @@ pub(super) struct SequenceStorage {
 }
 
 impl SequenceStorage {
-    pub(super) async fn new(path: &Path, used_space: UsedSpace) -> Result<Self> {
-        let chunks = SequenceChunkStore::new(path, used_space).await?;
+    pub(super) async fn new(path: &Path, max_capacity: u64) -> Result<Self> {
+        let chunks = SequenceChunkStore::new(path, max_capacity).await?;
+        Ok(Self { chunks })
+    }
+
+    pub(super) async fn from_used_space(path: &Path, used_space: &mut UsedSpace) -> Result<Self> {
+        let chunks = SequenceChunkStore::from_used_space(path, used_space).await?;
         Ok(Self { chunks })
     }
 

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -24,7 +24,7 @@ use xor_name::XorName;
 impl Node {
     ///
     pub async fn handle(&mut self, duty: NodeDuty) -> Result<NodeDuties> {
-        info!("Handling NodeDuty: {:?}", duty);
+        info!("Handling NodeD   uty: {:?}", duty);
         match duty {
             NodeDuty::Genesis => {
                 self.level_up().await?;
@@ -164,8 +164,11 @@ impl Node {
             NodeDuty::LevelDown => {
                 info!("Getting Demoted");
                 self.role = Role::Adult(AdultRole {
-                    chunks: Chunks::new(self.node_info.root_dir.as_path(), self.used_space.clone())
-                        .await?,
+                    chunks: Chunks::from_used_space(
+                        self.node_info.root_dir.as_path(),
+                        &mut self.used_space,
+                    )
+                    .await?,
                 });
                 Ok(vec![])
             }

--- a/src/node/member_churn.rs
+++ b/src/node/member_churn.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::chunk_store::UsedSpace;
 use crate::{
     capacity::{Capacity, ChunkHolderDbs, RateLimit},
     metadata::{adult_reader::AdultReader, Metadata},
@@ -42,8 +43,9 @@ impl Node {
         // start handling metadata
         let dbs = ChunkHolderDbs::new(self.node_info.path())?;
         let reader = AdultReader::new(self.network_api.clone());
+        let mut used_space = UsedSpace::from_existing_used_space(&mut self.used_space);
         let meta_data =
-            Metadata::new(&self.node_info.path(), &self.used_space, dbs, reader).await?;
+            Metadata::from_used_space(&self.node_info.path(), &mut used_space, dbs, reader).await?;
 
         //
         // start handling transfers

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -141,7 +141,7 @@ impl Node {
 
         let node = Self {
             role: Role::Adult(AdultRole {
-                chunks: Chunks::new(node_info.root_dir.as_path(), used_space.clone()).await?,
+                chunks: Chunks::new(node_info.root_dir.as_path(), config.max_capacity()).await?,
             }),
             node_info,
             used_space,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,7 +42,9 @@ pub(crate) fn new_auto_dump_db<D: AsRef<Path>, N: AsRef<Path>>(
 
 #[allow(dead_code)]
 pub(crate) fn random_vec<R: CryptoRng + Rng>(rng: &mut R, size: usize) -> Vec<u8> {
-    rng.sample_iter(&Standard).take(size).collect()
+    rng.sample_iter::<u8, Standard>(Standard)
+        .take(size)
+        .collect()
 }
 
 pub(crate) fn serialise<T: Serialize>(data: &T) -> Result<Bytes> {


### PR DESCRIPTION
- changes mutex to rwlocks 
- some functions do not need to be async due to the change
- gives fixed capacity for the buffers used for bincode so it allocates memory once per need instead of per byte