### PR TITLE
chore(log): log info about current node role, section prefix, age, and name upon every new routing event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.38.4"
+version = "0.38.5"
 dependencies = [
  "anyhow",
  "async-log",

--- a/src/capacity/rate_limit.rs
+++ b/src/capacity/rate_limit.rs
@@ -8,6 +8,7 @@
 
 use super::{Capacity, MAX_CHUNK_SIZE, MAX_SUPPLY};
 use crate::{network::Network, Result};
+use log::info;
 use sn_data_types::{PublicKey, Token};
 use xor_name::XorName;
 
@@ -38,14 +39,23 @@ impl RateLimit {
 
     /// Adds this node to the list of full nodes.
     pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
-        self.capacity.increase_full_node_count(node_id).await
+        self.capacity.increase_full_node_count(node_id).await?;
+        info!("No. of Full Nodes: {:?}", self.full_nodes().await);
+        Ok(())
     }
 
-    /// Adds this node to the list of full nodes.
+    /// Removes a given node from the list of full nodes.
     pub async fn decrease_full_node_count_if_present(&mut self, node_name: XorName) -> Result<()> {
         self.capacity
             .decrease_full_node_count_if_present(node_name)
-            .await
+            .await?;
+        info!("No. of Full Nodes: {:?}", self.full_nodes().await);
+        Ok(())
+    }
+
+    /// Returns the count of full_nodes.
+    pub async fn full_nodes(&self) -> u8 {
+        self.capacity.full_nodes().await
     }
 
     fn rate_limit(bytes: u64, full_nodes: u8, all_nodes: u8, prefix_len: usize) -> Token {

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -6,10 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::messaging::{send, send_to_nodes};
+use super::{
+    messaging::{send, send_to_nodes},
+    role::{AdultRole, Role},
+};
 use crate::{
     chunks::Chunks,
-    node::{AdultRole, Role},
     node_ops::{NodeDuties, NodeDuty, OutgoingMsg},
     section_funds::{reward_stage::RewardStage, Credits, SectionFunds},
     Error, Node, Result,

--- a/src/node/member_churn.rs
+++ b/src/node/member_churn.rs
@@ -6,10 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::role::{ElderRole, Role};
 use crate::{
     capacity::{Capacity, ChunkHolderDbs, RateLimit},
     metadata::{adult_reader::AdultReader, Metadata},
-    node::{ElderRole, Role},
     node_ops::NodeDuty,
     section_funds::{reward_wallets::RewardWallets, SectionFunds},
     transfers::{

--- a/src/node/role.rs
+++ b/src/node/role.rs
@@ -1,0 +1,74 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{
+    chunks::Chunks, metadata::Metadata, section_funds::SectionFunds, transfers::Transfers, Error,
+    Result,
+};
+use std::fmt;
+
+pub(crate) struct AdultRole {
+    // immutable chunks
+    pub chunks: Chunks,
+}
+
+pub(crate) struct ElderRole {
+    // data operations
+    pub meta_data: Metadata,
+    // transfers
+    pub transfers: Transfers,
+    // reward payouts
+    pub section_funds: SectionFunds,
+    // denotes if we received initial sync
+    pub received_initial_sync: bool,
+}
+
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum Role {
+    Adult(AdultRole),
+    Elder(ElderRole),
+}
+
+impl Role {
+    pub fn as_adult(&self) -> Result<&AdultRole> {
+        match self {
+            Self::Adult(adult) => Ok(adult),
+            _ => Err(Error::NotAnAdult),
+        }
+    }
+
+    pub fn as_adult_mut(&mut self) -> Result<&mut AdultRole> {
+        match self {
+            Self::Adult(adult) => Ok(adult),
+            _ => Err(Error::NotAnAdult),
+        }
+    }
+
+    pub fn as_elder(&self) -> Result<&ElderRole> {
+        match self {
+            Self::Elder(elder) => Ok(elder),
+            _ => Err(Error::NotAnElder),
+        }
+    }
+
+    pub fn as_elder_mut(&mut self) -> Result<&mut ElderRole> {
+        match self {
+            Self::Elder(elder) => Ok(elder),
+            _ => Err(Error::NotAnElder),
+        }
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Elder(_) => write!(f, "Elder"),
+            Self::Adult(_) => write!(f, "Adult"),
+        }
+    }
+}


### PR DESCRIPTION
Minor refactor also moving Role to its own file.

Example log entry:
```
[sn_node] INFO 2021-04-22T20:57:51.648325846-03:00 [src/node/mod.rs:127] New RoutingEvent received. Current role: Adult, section prefix: Prefix(10), age: 5, node name: b0e5a6..
```