### PR TITLE
fix(capacity): allow joins after split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.38.7"
+version = "0.38.8"
 dependencies = [
  "anyhow",
  "async-log",

--- a/src/capacity/mod.rs
+++ b/src/capacity/mod.rs
@@ -9,12 +9,8 @@
 mod chunk_dbs;
 mod rate_limit;
 
-use crate::{Error, Result};
 pub use chunk_dbs::ChunkHolderDbs;
-use log::{error, info};
 pub use rate_limit::RateLimit;
-use sn_data_types::PublicKey;
-use xor_name::XorName;
 
 pub const MAX_SUPPLY: u64 = u32::MAX as u64 * 1_000_000_000_u64;
 const MAX_CHUNK_SIZE: u64 = 1_000_000;
@@ -36,43 +32,5 @@ impl Capacity {
     /// Number of full chunk storing nodes in the section.
     pub async fn full_nodes(&self) -> u8 {
         self.dbs.full_adults.lock().await.total_keys() as u8
-    }
-
-    ///
-    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
-        info!("Increasing full_node count");
-        let _ = self
-            .dbs
-            .full_adults
-            .lock()
-            .await
-            .lcreate(&XorName::from(node_id).to_string())?
-            .ladd(&"Node Full");
-        Ok(())
-    }
-
-    ///
-    pub async fn decrease_full_node_count_if_present(&mut self, node_name: XorName) -> Result<()> {
-        info!("Checking to decrease full_node count for: {:?}", node_name);
-        match self
-            .dbs
-            .full_adults
-            .lock()
-            .await
-            .rem(&node_name.to_string())
-        {
-            Ok(true) => {
-                info!("Node present in DB, remove successful");
-                Ok(())
-            }
-            Ok(false) => {
-                info!("Node not found on full_nodes db");
-                Ok(())
-            }
-            Err(e) => {
-                error!("Error removing from full_nodes db");
-                Err(Error::PickleDb(e))
-            }
-        }
     }
 }

--- a/src/capacity/rate_limit.rs
+++ b/src/capacity/rate_limit.rs
@@ -7,10 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Capacity, MAX_CHUNK_SIZE, MAX_SUPPLY};
-use crate::{network::Network, Result};
-use log::{debug, info};
-use sn_data_types::{PublicKey, Token};
-use xor_name::XorName;
+use crate::network::Network;
+use log::debug;
+use sn_data_types::Token;
 
 /// Calculation of rate limit for writes.
 #[derive(Clone)]
@@ -35,27 +34,6 @@ impl RateLimit {
         let all_nodes = self.network.our_adults().await.len() as u8;
 
         RateLimit::rate_limit(bytes, full_nodes, all_nodes, prefix_len)
-    }
-
-    /// Adds this node to the list of full nodes.
-    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
-        self.capacity.increase_full_node_count(node_id).await?;
-        info!("No. of Full Nodes: {:?}", self.full_nodes().await);
-        Ok(())
-    }
-
-    /// Removes a given node from the list of full nodes.
-    pub async fn decrease_full_node_count_if_present(&mut self, node_name: XorName) -> Result<()> {
-        self.capacity
-            .decrease_full_node_count_if_present(node_name)
-            .await?;
-        info!("No. of Full Nodes: {:?}", self.full_nodes().await);
-        Ok(())
-    }
-
-    /// Returns the count of full_nodes.
-    pub async fn full_nodes(&self) -> u8 {
-        self.capacity.full_nodes().await
     }
 
     fn rate_limit(bytes: u64, full_nodes: u8, all_nodes: u8, prefix_len: usize) -> Token {

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -24,7 +24,7 @@ use elder_stores::ElderStores;
 use map_storage::MapStorage;
 use register_storage::RegisterStorage;
 use sequence_storage::SequenceStorage;
-use sn_data_types::Blob;
+use sn_data_types::{Blob, PublicKey};
 use sn_messaging::{
     client::{DataCmd, DataExchange, DataQuery, NodeCmdResult, QueryResponse},
     EndUser, MessageId,
@@ -113,6 +113,22 @@ impl Metadata {
         origin: EndUser,
     ) -> Result<NodeDuty> {
         writing::get_result(cmd, id, origin, &mut self.elder_stores).await
+    }
+
+    /// Adds a given node to the list of full nodes.
+    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
+        self.elder_stores
+            .blob_records_mut()
+            .increase_full_node_count(node_id)
+            .await
+    }
+
+    /// Removes a given node from the list of full nodes.
+    pub async fn decrease_full_node_count_if_present(&mut self, node_name: XorName) -> Result<()> {
+        self.elder_stores
+            .blob_records_mut()
+            .decrease_full_node_count_if_present(node_name)
+            .await
     }
 
     // This should be called whenever a node leaves the section. It fetches the list of data that was

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -120,6 +120,7 @@ impl Node {
                         "COMPLETED SPLIT. New section: ({}). Total rewards paid: {}.",
                         section_key, reward_sum
                     );
+                    ops.push(NodeDuty::SetNodeJoinsAllowed(true));
                 }
 
                 Ok(ops)
@@ -169,7 +170,7 @@ impl Node {
                 let elder = self.role.as_elder_mut()?;
                 elder.section_funds.remove_node_wallet(name);
                 elder
-                    .transfers
+                    .meta_data
                     .decrease_full_node_count_if_present(name)
                     .await?;
 
@@ -306,7 +307,7 @@ impl Node {
             // ------- Misc ------------
             NodeDuty::IncrementFullNodeCount { node_id } => {
                 let elder = self.role.as_elder_mut()?;
-                elder.transfers.increase_full_node_count(node_id).await?;
+                elder.meta_data.increase_full_node_count(node_id).await?;
                 // Accept a new node in place for the full node.
                 Ok(vec![NodeDuty::SetNodeJoinsAllowed(true)])
             }

--- a/src/transfers/mod.rs
+++ b/src/transfers/mod.rs
@@ -23,7 +23,6 @@ use log::{debug, error, info, trace, warn};
 use replica_signing::ReplicaSigningImpl;
 #[cfg(feature = "simulated-payouts")]
 use sn_data_types::Transfer;
-use sn_routing::XorName;
 use std::collections::{BTreeMap, HashSet};
 
 use futures::lock::Mutex;
@@ -111,18 +110,6 @@ impl Transfers {
     pub async fn split_section(&self, prefix: Prefix) -> Result<()> {
         // Removes keys that are no longer our section responsibility.
         self.replicas.keep_keys_of(prefix).await
-    }
-
-    ///
-    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
-        self.rate_limit.increase_full_node_count(node_id).await
-    }
-
-    ///
-    pub async fn decrease_full_node_count_if_present(&mut self, node_name: XorName) -> Result<()> {
-        self.rate_limit
-            .decrease_full_node_count_if_present(node_name)
-            .await
     }
 
     /// Get latest StoreCost for the given number of bytes.


### PR DESCRIPTION
- Needed as there will be no `MemberLeft`event when there is a split, and a handful of adults are "lost" as they are promoted.