### PR TITLE
ci: default to prerelease fot github releases

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -172,7 +172,7 @@ jobs:
           tag_name: v${{ steps.versioning.outputs.version }}
           release_name: sn_node v${{ steps.versioning.outputs.version }}
           draft: false
-          prerelease: false
+          prerelease: true
           body_path: RELEASE_DESCRIPTION.txt
 
       # Upload zip files


### PR DESCRIPTION
dont't bump  automatically