### PR TITLE
refactor(capacity): move capacity related code out of BlobRecords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "async-log",

--- a/src/capacity/mod.rs
+++ b/src/capacity/mod.rs
@@ -9,28 +9,175 @@
 mod adult_storage_info;
 mod store_cost;
 
+use std::collections::BTreeSet;
+
 pub use adult_storage_info::AdultsStorageInfo;
+use sn_routing::{Prefix, XorName};
 pub use store_cost::StoreCost;
 
+use crate::metadata::adult_reader::AdultReader;
+
 pub const MAX_SUPPLY: u64 = u32::MAX as u64 * 1_000_000_000_u64;
-const MAX_CHUNK_SIZE: u64 = 1_000_000;
+// The number of separate copies of a blob chunk which should be maintained.
+pub(crate) const CHUNK_COPY_COUNT: usize = 4;
+pub(crate) const MAX_CHUNK_SIZE: u64 = 1_000_000;
 
 /// A util for sharing the
 /// info on data capacity among the
 /// chunk storing nodes in the section.
 #[derive(Clone)]
 pub struct Capacity {
-    adult_storage_info: AdultsStorageInfo,
+    reader: CapacityReader,
+    writer: CapacityWriter,
 }
 
 impl Capacity {
     /// Pass in adult_storage_info with info on chunk holders.
-    pub(super) fn new(adult_storage_info: AdultsStorageInfo) -> Self {
-        Self { adult_storage_info }
+    pub(super) fn new(reader: CapacityReader, writer: CapacityWriter) -> Self {
+        Self { reader, writer }
+    }
+
+    /// Get the sections's current Prefix
+    pub async fn our_prefix(&self) -> Prefix {
+        self.reader.our_prefix().await
+    }
+
+    /// Whether the adult is recorded as full
+    pub async fn is_full(&self, adult: &XorName) -> bool {
+        self.reader.is_full(adult).await
     }
 
     /// Number of full chunk storing nodes in the section.
-    pub async fn full_nodes(&self) -> u8 {
+    pub async fn full_adults_count(&self) -> u8 {
+        self.reader.full_adults_count().await
+    }
+
+    /// Number of full chunk storing nodes in the section.
+    pub async fn full_adults_matching(&self, prefix: Prefix) -> BTreeSet<XorName> {
+        self.reader.full_adults_matching(prefix).await
+    }
+
+    // Returns `XorName`s of the target holders for an Blob chunk.
+    // Used to fetch the list of holders for a new chunk.
+    pub async fn get_chunk_holder_adults(&self, target: &XorName) -> BTreeSet<XorName> {
+        self.reader.get_chunk_holder_adults(target).await
+    }
+
+    pub async fn insert_full_adults(&self, full_adults: BTreeSet<XorName>) {
+        self.writer.insert_full_adults(full_adults).await
+    }
+
+    pub async fn remove_full_adults(&self, full_adults: BTreeSet<XorName>) {
+        self.writer.remove_full_adults(full_adults).await
+    }
+
+    /// Registered holders not present in provided list of members
+    /// will be removed from adult_storage_info and no longer tracked for liveness.
+    pub async fn retain_members_only(&mut self, members: &BTreeSet<XorName>) {
+        self.writer.retain_members_only(members).await
+    }
+}
+
+#[derive(Clone)]
+pub struct CapacityReader {
+    reader: AdultReader,
+    adult_storage_info: AdultsStorageInfo,
+}
+
+#[derive(Clone)]
+pub struct CapacityWriter {
+    reader: AdultReader,
+    adult_storage_info: AdultsStorageInfo,
+}
+
+impl CapacityReader {
+    /// Pass in adult_storage_info with info on chunk holders.
+    pub(super) fn new(adult_storage_info: AdultsStorageInfo, reader: AdultReader) -> Self {
+        Self {
+            reader,
+            adult_storage_info,
+        }
+    }
+
+    /// Get the sections's current Prefix
+    pub async fn our_prefix(&self) -> Prefix {
+        self.reader.our_prefix().await
+    }
+
+    /// Whether the adult is recorded as full
+    pub async fn is_full(&self, adult: &XorName) -> bool {
+        self.adult_storage_info
+            .full_adults
+            .read()
+            .await
+            .contains(adult)
+    }
+
+    /// Number of full chunk storing nodes in the section.
+    pub async fn full_adults_count(&self) -> u8 {
         self.adult_storage_info.full_adults.read().await.len() as u8
+    }
+
+    /// Number of full chunk storing nodes in the section.
+    pub async fn full_adults_matching(&self, prefix: Prefix) -> BTreeSet<XorName> {
+        self.adult_storage_info
+            .full_adults
+            .read()
+            .await
+            .iter()
+            .filter(|name| prefix.matches(name))
+            .copied()
+            .collect()
+    }
+
+    // Returns `XorName`s of the target holders for an Blob chunk.
+    // Used to fetch the list of holders for a new chunk.
+    pub async fn get_chunk_holder_adults(&self, target: &XorName) -> BTreeSet<XorName> {
+        let full_adults = self.adult_storage_info.full_adults.read().await;
+        self.reader
+            .non_full_adults_closest_to(&target, &full_adults, CHUNK_COPY_COUNT)
+            .await
+    }
+}
+
+impl CapacityWriter {
+    /// Pass in adult_storage_info with info on chunk holders.
+    pub(super) fn new(adult_storage_info: AdultsStorageInfo, reader: AdultReader) -> Self {
+        Self {
+            reader,
+            adult_storage_info,
+        }
+    }
+
+    pub async fn insert_full_adults(&self, full_adults: BTreeSet<XorName>) {
+        let mut orig_full_adults = self.adult_storage_info.full_adults.write().await;
+
+        for adult in full_adults {
+            let _ = orig_full_adults.insert(adult);
+        }
+    }
+
+    pub async fn remove_full_adults(&self, full_adults: BTreeSet<XorName>) {
+        let mut orig_full_adults = self.adult_storage_info.full_adults.write().await;
+
+        for adult in full_adults {
+            let _ = orig_full_adults.remove(&adult);
+        }
+    }
+
+    /// Registered holders not present in provided list of members
+    /// will be removed from adult_storage_info and no longer tracked for liveness.
+    pub async fn retain_members_only(&mut self, members: &BTreeSet<XorName>) {
+        // full adults
+        let mut full_adults = self.adult_storage_info.full_adults.write().await;
+        let absent_adults = full_adults
+            .iter()
+            .filter(|&key| !members.contains(key))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for adult in &absent_adults {
+            let _ = full_adults.remove(adult);
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -159,7 +159,7 @@ pub enum Error {
     InvalidMessage(MessageId, String),
     /// Data owner provided is invalid.
     #[error("Provided PublicKey is not a valid owner. Provided PublicKey: {0}")]
-    InvalidOwners(PublicKey),
+    InvalidOwner(PublicKey),
     /// Operation is invalid, eg signing validation
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
@@ -181,7 +181,7 @@ pub(crate) fn convert_to_error_message(error: Error) -> sn_messaging::client::Er
     match error {
         Error::InvalidOperation(msg) => ErrorMessage::InvalidOperation(msg),
         Error::InvalidMessage(_, msg) => ErrorMessage::InvalidOperation(msg),
-        Error::InvalidOwners(key) => ErrorMessage::InvalidOwners(key),
+        Error::InvalidOwner(key) => ErrorMessage::InvalidOwners(key),
         Error::InvalidSignedTransfer(_) => ErrorMessage::InvalidSignature,
         Error::TransferAlreadyRegistered => ErrorMessage::TransactionIdExists,
         Error::NoSuchChunk(address) => ErrorMessage::DataNotFound(address),

--- a/src/metadata/adult_liveness.rs
+++ b/src/metadata/adult_liveness.rs
@@ -14,6 +14,8 @@ use sn_messaging::{EndUser, MessageId};
 use sn_routing::XorName;
 use std::collections::hash_map::Entry;
 
+use crate::capacity::CHUNK_COPY_COUNT;
+
 const NEIGHBOUR_COUNT: usize = 2;
 const MIN_PENDING_OPS: usize = 10;
 const PENDING_OP_TOLERANCE_RATIO: f64 = 0.1;
@@ -118,7 +120,7 @@ impl AdultLiveness {
                 responded_with_success,
             } = op;
 
-            if targets.len() < super::CHUNK_COPY_COUNT && *responded_with_success {
+            if targets.len() < CHUNK_COPY_COUNT && *responded_with_success {
                 None
             } else {
                 *responded_with_success = success;

--- a/src/metadata/adult_reader.rs
+++ b/src/metadata/adult_reader.rs
@@ -34,13 +34,13 @@ impl AdultReader {
         name: &XorName,
         full_adults: &BTreeSet<XorName>,
         count: usize,
-    ) -> Vec<XorName> {
+    ) -> BTreeSet<XorName> {
         self.network
             .our_adults_sorted_by_distance_to(name)
             .await
             .into_iter()
             .filter(|name| !full_adults.contains(name))
             .take(count)
-            .collect::<Vec<_>>()
+            .collect::<BTreeSet<_>>()
     }
 }

--- a/src/metadata/blob_records.rs
+++ b/src/metadata/blob_records.rs
@@ -7,12 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    capacity::AdultsStorageInfo,
+    btree_set,
+    capacity::{Capacity, CHUNK_COPY_COUNT},
     error::convert_to_error_message,
     node_ops::{NodeDuties, NodeDuty},
     Error, Result,
 };
-use log::{debug, info, warn};
+use log::{info, warn};
 use sn_data_types::{Blob, BlobAddress, PublicKey};
 use sn_messaging::{
     client::{BlobDataExchange, BlobRead, BlobWrite, ClientSigned, CmdError, QueryResponse},
@@ -28,70 +29,39 @@ use std::{
 use xor_name::XorName;
 
 use super::{
-    adult_liveness::AdultLiveness, adult_reader::AdultReader, build_client_error_response,
-    build_client_query_response,
+    adult_liveness::AdultLiveness, build_client_error_response, build_client_query_response,
 };
-
-// The number of separate copies of a blob chunk which should be maintained.
-pub(crate) const CHUNK_COPY_COUNT: usize = 4;
 
 /// Operations over the data type Blob.
 pub(super) struct BlobRecords {
-    adult_storage_info: AdultsStorageInfo,
-    reader: AdultReader,
+    capacity: Capacity,
     adult_liveness: AdultLiveness,
 }
 
 impl BlobRecords {
-    pub(super) fn new(adult_storage_info: AdultsStorageInfo, reader: AdultReader) -> Self {
+    pub(super) fn new(capacity: Capacity) -> Self {
         Self {
-            adult_storage_info,
-            reader,
+            capacity,
             adult_liveness: AdultLiveness::new(),
         }
     }
 
     pub async fn get_data_of(&self, prefix: Prefix) -> BlobDataExchange {
         // Prepare full_adult details
-        let full_adults = self
-            .adult_storage_info
-            .full_adults
-            .read()
-            .await
-            .iter()
-            .filter(|name| prefix.matches(name))
-            .copied()
-            .collect();
+        let full_adults = self.capacity.full_adults_matching(prefix).await;
         BlobDataExchange { full_adults }
     }
 
-    pub async fn update(&self, blob_data: BlobDataExchange) -> Result<()> {
-        debug!("Updating Blob records");
-        let mut orig_full_adults = self.adult_storage_info.full_adults.write().await;
-
+    pub async fn update(&self, blob_data: BlobDataExchange) {
         let BlobDataExchange { full_adults } = blob_data;
-
-        for adult in full_adults {
-            let _ = orig_full_adults.insert(adult);
-        }
-
-        Ok(())
+        self.capacity.insert_full_adults(full_adults).await
     }
 
     /// Registered holders not present in provided list of members
     /// will be removed from adult_storage_info and no longer tracked for liveness.
     pub async fn retain_members_only(&mut self, members: BTreeSet<XorName>) -> Result<()> {
         // full adults
-        let mut full_adults = self.adult_storage_info.full_adults.write().await;
-        let absent_adults = full_adults
-            .iter()
-            .filter(|key| !members.contains(key))
-            .cloned()
-            .collect::<Vec<_>>();
-
-        for adult in &absent_adults {
-            let _ = full_adults.remove(adult);
-        }
+        self.capacity.retain_members_only(&members).await;
 
         // stop tracking liveness of absent holders
         self.adult_liveness.retain_members_only(members);
@@ -114,44 +84,28 @@ impl BlobRecords {
     }
 
     /// Adds a given node to the list of full nodes.
-    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
-        info!("No. of Full Nodes: {:?}", self.full_nodes().await);
-        info!("Increasing full_node count");
-        let _ = self
-            .adult_storage_info
-            .full_adults
-            .write()
-            .await
-            .insert(XorName::from(node_id));
-        Ok(())
+    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) {
+        info!(
+            "No. of full Adults: {:?}",
+            self.capacity.full_adults_count().await
+        );
+        info!("Increasing full Adults count");
+        self.capacity
+            .insert_full_adults(btree_set!(XorName::from(node_id)))
+            .await;
     }
 
     /// Removes a given node from the list of full nodes.
     #[allow(unused)] // TODO: Remove node from full list at 50% ?
-    async fn decrease_full_node_count_if_present(&mut self, node_name: XorName) -> Result<()> {
-        info!("No. of Full Nodes: {:?}", self.full_nodes().await);
+    async fn decrease_full_adults_count_if_present(&mut self, node_name: XorName) {
+        info!(
+            "No. of Full Nodes: {:?}",
+            self.capacity.full_adults_count().await
+        );
         info!("Checking if {:?} is present as full_node", node_name);
-        match self
-            .adult_storage_info
-            .full_adults
-            .write()
-            .await
-            .remove(&node_name)
-        {
-            true => {
-                info!("Node present in DB, remove successful");
-                Ok(())
-            }
-            false => {
-                info!("Node not found on full_nodes db");
-                Ok(())
-            }
-        }
-    }
-
-    /// Number of full chunk storing nodes in the section.
-    async fn full_nodes(&self) -> u8 {
-        self.adult_storage_info.full_adults.read().await.len() as u8
+        self.capacity
+            .remove_full_adults(btree_set!(node_name))
+            .await;
     }
 
     async fn send_chunks_to_adults(
@@ -161,19 +115,14 @@ impl BlobRecords {
         client_signed: ClientSigned,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        let target_holders = self
-            .get_holders_for_chunk(data.name())
-            .await
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<_>>();
+        let target_holders = self.capacity.get_chunk_holder_adults(data.name()).await;
 
         info!("Storing {} copies of the data", target_holders.len());
 
-        if target_holders.is_empty() {
+        if CHUNK_COPY_COUNT > target_holders.len() {
             return self
                 .send_error(
-                    Error::NoAdults(self.reader.our_prefix().await),
+                    Error::NoAdults(self.capacity.our_prefix().await),
                     msg_id,
                     origin,
                 )
@@ -229,9 +178,8 @@ impl BlobRecords {
             &src,
             response.is_success(),
         ) {
-            let full_adults = self.adult_storage_info.full_adults.read().await;
             // If a full adult responds with error. Drop the response
-            if full_adults.contains(&src) && !response.is_success() {
+            if !response.is_success() && self.capacity.is_full(&src).await {
                 // We've already responded already with a success
                 // so do nothing
             } else {
@@ -277,8 +225,7 @@ impl BlobRecords {
         client_signed: ClientSigned,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        let targets = self.get_holders_for_chunk(address.name()).await;
-        let targets = targets.iter().cloned().collect::<BTreeSet<_>>();
+        let targets = self.capacity.get_chunk_holder_adults(address.name()).await;
 
         let msg = NodeMsg::NodeCmd {
             cmd: NodeCmd::Chunks {
@@ -297,13 +244,7 @@ impl BlobRecords {
 
     pub(super) async fn republish_chunk(&mut self, data: Blob) -> Result<NodeDuty> {
         let owner = data.owner();
-
-        let target_holders = self
-            .get_holders_for_chunk(data.name())
-            .await
-            .into_iter()
-            .collect::<BTreeSet<_>>();
-
+        let target_holders = self.capacity.get_chunk_holder_adults(data.name()).await;
         // deterministic msg id for aggregation
         let msg_id = MessageId::from_content(&(*data.name(), owner, &target_holders))?;
 
@@ -341,18 +282,12 @@ impl BlobRecords {
         msg_id: MessageId,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        let targets = self.get_holders_for_chunk(address.name()).await;
-        let full_adults = self.adult_storage_info.full_adults.read().await.clone();
-
-        let targets = targets
-            .into_iter()
-            .chain(full_adults.into_iter())
-            .collect::<BTreeSet<_>>();
+        let targets = self.capacity.get_chunk_holder_adults(address.name()).await;
 
         if targets.is_empty() {
             return self
                 .send_error(
-                    Error::NoAdults(self.reader.our_prefix().await),
+                    Error::NoAdults(self.capacity.our_prefix().await),
                     msg_id,
                     origin,
                 )
@@ -384,24 +319,15 @@ impl BlobRecords {
             Ok(NodeDuty::NoOp)
         }
     }
-
-    // Returns `XorName`s of the target holders for an Blob chunk.
-    // Used to fetch the list of holders for a new chunk.
-    async fn get_holders_for_chunk(&self, target: &XorName) -> Vec<XorName> {
-        let full_adults = self.adult_storage_info.full_adults.read().await;
-        self.reader
-            .non_full_adults_closest_to(&target, &full_adults, CHUNK_COPY_COUNT)
-            .await
-    }
 }
 
 fn validate_data_owner(data: &Blob, requester: &PublicKey) -> Result<()> {
     if data.is_private() {
         data.owner()
-            .ok_or_else(|| Error::InvalidOwners(*requester))
+            .ok_or_else(|| Error::InvalidOwner(*requester))
             .and_then(|data_owner| {
                 if data_owner != requester {
-                    Err(Error::InvalidOwners(*requester))
+                    Err(Error::InvalidOwner(*requester))
                 } else {
                     Ok(())
                 }

--- a/src/metadata/elder_stores.rs
+++ b/src/metadata/elder_stores.rs
@@ -123,7 +123,7 @@ impl ElderStores {
     pub async fn update(&mut self, data: DataExchange) -> Result<(), Error> {
         self.map_storage.update(data.map_data).await?;
         self.sequence_storage.update(data.seq_data).await?;
-        self.blob_records.update(data.blob_data).await?;
+        self.blob_records.update(data.blob_data).await;
 
         Ok(())
     }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -14,15 +14,12 @@ mod map_storage;
 mod register_storage;
 mod sequence_storage;
 
-use self::adult_reader::AdultReader;
-use super::node_ops::NodeDuty;
 use crate::{
-    capacity::AdultsStorageInfo,
-    node_ops::{MsgType, NodeDuties, OutgoingMsg},
+    capacity::Capacity,
+    node_ops::{MsgType, NodeDuties, NodeDuty, OutgoingMsg},
     Result,
 };
 use blob_records::BlobRecords;
-pub(crate) use blob_records::CHUNK_COPY_COUNT;
 use elder_stores::ElderStores;
 use map_storage::MapStorage;
 use register_storage::RegisterStorage;
@@ -54,13 +51,8 @@ pub struct Metadata {
 }
 
 impl Metadata {
-    pub async fn new(
-        path: &Path,
-        max_capacity: u64,
-        adult_storage_info: AdultsStorageInfo,
-        reader: AdultReader,
-    ) -> Result<Self> {
-        let blob_records = BlobRecords::new(adult_storage_info, reader);
+    pub async fn new(path: &Path, max_capacity: u64, capacity: Capacity) -> Result<Self> {
+        let blob_records = BlobRecords::new(capacity);
         let map_storage = MapStorage::new(path, max_capacity).await?;
         let sequence_storage = SequenceStorage::new(path, max_capacity).await?;
         let register_storage = RegisterStorage::new(path, max_capacity).await?;
@@ -116,7 +108,7 @@ impl Metadata {
     }
 
     /// Adds a given node to the list of full nodes.
-    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<()> {
+    pub async fn increase_full_node_count(&mut self, node_id: PublicKey) {
         self.elder_stores
             .blob_records_mut()
             .increase_full_node_count(node_id)

--- a/src/metadata/register_storage.rs
+++ b/src/metadata/register_storage.rs
@@ -140,7 +140,7 @@ impl RegisterStorage {
             }
 
             if requester != register.owner() {
-                Err(Error::InvalidOwners(requester))
+                Err(Error::InvalidOwner(requester))
             } else {
                 Ok(())
             }

--- a/src/metadata/sequence_storage.rs
+++ b/src/metadata/sequence_storage.rs
@@ -176,7 +176,7 @@ impl SequenceStorage {
 
             let policy = sequence.private_policy(Some(requester))?;
             if requester != policy.owner {
-                Err(Error::InvalidOwners(requester))
+                Err(Error::InvalidOwner(requester))
             } else {
                 Ok(())
             }

--- a/src/node/handle.rs
+++ b/src/node/handle.rs
@@ -506,7 +506,7 @@ impl Node {
                         .write()
                         .await
                         .increase_full_node_count(node_id)
-                        .await?;
+                        .await;
                     // Accept a new node in place for the full node.
                     Ok(NodeTask::from(vec![NodeDuty::SetNodeJoinsAllowed(true)]))
                 });

--- a/src/node/role/adult_role.rs
+++ b/src/node/role/adult_role.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
+    capacity::CHUNK_COPY_COUNT,
     chunks::Chunks,
-    metadata::CHUNK_COPY_COUNT,
     node_ops::{NodeDuties, NodeDuty},
 };
 use itertools::Itertools;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,6 +20,42 @@ use std::{fs, path::Path};
 
 const NODE_MODULE_NAME: &str = "sn_node";
 
+/// Easily create a `BTreeSet`.
+#[macro_export]
+macro_rules! btree_set {
+    ($($item:expr),*) => {{
+        let mut _set = ::std::collections::BTreeSet::new();
+        $(
+            let _ = _set.insert($item);
+        )*
+        _set
+    }};
+
+    ($($item:expr),*,) => {
+        btree_set![$($item),*]
+    };
+}
+
+/// Easily create a `BTreeMap` with the key => value syntax.
+#[macro_export]
+macro_rules! btree_map {
+    () => ({
+        ::std::collections::BTreeMap::new()
+    });
+
+    ($($key:expr => $value:expr),*) => {{
+        let mut _map = ::std::collections::BTreeMap::new();
+        $(
+            let _ = _map.insert($key, $value);
+        )*
+        _map
+    }};
+
+    ($($key:expr => $value:expr),*,) => {
+        btree_map![$($key => $value),*]
+    };
+}
+
 pub(crate) fn new_auto_dump_db<D: AsRef<Path>, N: AsRef<Path>>(
     db_dir: D,
     db_name: N,


### PR DESCRIPTION
- Also, make sure only a reader is passed in to Metadata, thus decoupling it from Capacity regulating code.
- Clarifies that we count _adults_ when checking storage capacity.
- Updates store cost function to work better with current est. section size.
- Returns NoAdults error when less than chunk copy count available for store.
- Only read full adults if response was not success.
- Remove wasteful mapping to Vec, when only BTreeSet is used.